### PR TITLE
docs: Revamp OAuth 2.0 guide with PKCE flow, examples, and troubleshooting

### DIFF
--- a/docs/tutorials/oidc/getting-started-with-oauth2.mdx
+++ b/docs/tutorials/oidc/getting-started-with-oauth2.mdx
@@ -4,69 +4,371 @@ sidebar_position: 1
 
 # Using OAuth 2.0 to Access Quran.Foundation APIs
 
-Quran.Foundation APIs use the [OAuth 2.0 protocol](https://www.rfc-editor.org/rfc/rfc6749) for authentication and authorization. Quran.Foundation supports common OAuth 2.0 scenarios such as those for web server, client-side, installed, and limited-input device applications.
+Quran.Foundation User APIs use the OAuth 2.0 Authorization Code flow with PKCE for authenticating users and authorizing access to their data. This guide mirrors our Quick Start style: clear steps, tips, and ready-to-run examples in Python (requests) and JavaScript (Node + axios).
 
-To begin, [obtain OAuth 2.0 client credentials](#obtaining-oauth-20-client-credentials) from Quran.Foundation. Then your client application requests an access token from Quran.Foundation Authorization server, extracts a token from the response, and sends the token to the Quran.Foundation API that you want to access.
+For identity details (ID token), see [OpenID Connect](/docs/tutorials/oidc/openid-connect).
 
-This page gives an overview of the OAuth 2.0 authorization scenarios that Quran.Foundation supports, and provides links to more detailed content. For details about using OAuth 2.0 for authentication, see [OpenID Connect](/docs/tutorials/oidc/openid-connect).
+> 🔀 Flow split: Use Client Credentials for Content APIs (see [Quick Start](/docs/quickstart)). Use Authorization Code (+PKCE) for User APIs (this page).
 
-# Overview
+---
+
+## Overview
 
 Here's how the OAuth2 process works in a common scenario where user consent is needed to access their data:
 
 ![oauth2 process](/img/oauth2-process.png)
 
-## Obtaining OAuth 2.0 client credentials
-
-Please submit an [Application](/request-access) to get your client credentials.
-
-# Basic steps
-
-All applications follow a basic pattern when accessing a Quran.Foundation API using OAuth 2.0. At a high level, you follow five steps:
-
-1. Obtain OAuth 2.0 credentials by contacting us.
-
-Submit an [Application](/request-access) to obtain OAuth 2.0 credentials such as a client ID and client secret that are known to both Quran.Foundation and your application. The set of values varies based on what type of application you are building. For example, a JavaScript application does not require a secret, but a web server application does.
-
-2. Obtain an access token from the Quran.Foundation Authorization server.
-
-Before your application can access private data using a quran.com API, it must obtain an access token that grants access to that API. A single access token can grant varying degrees of access to multiple APIs. A variable parameter called scope controls the set of resources and operations that an access token permits. During the access-token request, your application sends one or more values in the scope parameter.
-
-Some requests require an authentication step where the user logs in with their Quran.Foundation account. After logging in, the user is asked whether they are willing to grant one or more permissions that your application is requesting. This process is called user consent.
-
-If the user grants at least one permission, the Quran.Foundation Authorization server sends your application an access token (or an authorization code that your application can use to obtain an access token) and a list of scopes of access granted by that token. If the user does not grant the permission, the server returns an error.
-
-It is generally a best practice to request scopes incrementally, at the time access is required, rather than up front. For example, an app that wants to support saving a bookmark should not request Bookmark access until the user presses the "Bookmark Ayah" button.
-
-To request an access token, you will need to generate an authorization URL. This URL will contain the necessary parameters that will be used to authenticate the request and should include the following parameters:
-
-```
-- response_type: The type of response you are expecting (e.g. “code” for an authorization code)
-- client_id: Your application’s Client ID
-- redirect_uri: The URL where the user should be redirected after authentication
-- scope: The scope of access the user is granting (e.g. “read” to read data from their account)
-- state: An optional parameter that can be used to verify the request
-```
-
-3. Examine scopes of access granted by the user.
-
-Compare the scopes included in the access token response to the scopes required to access features and functionality of your application dependent upon access to a related Quran.Foundation API. Disable any features of your app unable to function without access to the related API.
-
-4. Send the access token to an API.
-
-After an application obtains an access token, it sends the token to a Quran.Foundation API in HTTP x-auth-token request header.
-
-Access tokens are valid only for the set of operations and resources described in the scope of the token request. For example, if an access token is issued for the Quran.Foundation Bookmark API, it does not grant access to the Quran.Foundation Collection API. You can, however, send that access token to the Quran.Foundation Bookmark API multiple times for similar operations.
-
-5. Refresh the access token, if necessary.
-
-Access tokens have limited lifetimes. If your application needs access to a Quran.Foundation API beyond the lifetime of a single access token, it can obtain a refresh token. A refresh token allows your application to obtain new access tokens.
-
-**_Note: Save refresh tokens in secure long-term storage and continue to use them as long as they remain valid._**
-{/* Limits apply to the number of refresh tokens that are issued per client-user combination, and per user across all clients, and these limits are different. If your application requests enough refresh tokens to go over one of the limits, older refresh tokens stop working. */}
+> 🔧 Further examples: See our [Example OAuth2 client](https://github.com/quran/quran-oauth2-example)  
+> and the hosted demo [here](https://oauth2-client-example.quran.foundation/).
 
 ---
 
-## Example
+## 🧩 Step 1: Request OAuth 2.0 Client Credentials
 
-We have created an [Example OAuth2 client](https://github.com/quran/quran-oauth2-example) that executes step 2 (authorzation request) and receives a callback with tokens required to perform steps 4 and 5 upon successful authorization request. We have used the Example client to connect to Quran.Foundation Authorization server which can be found [here](https://oauth2-client-example.quran.foundation/). The generated accessToken resulting from the callback can be used to access V1 resource server APIs listed [here](/docs/category/user-related-apis).
+1. Submit an [Application](/request-access) to obtain your `client_id` and (for confidential apps) `client_secret`.
+2. Provide one or more exact `redirect_uri` values. These must match exactly at runtime.
+
+> ⚠️ Never embed `client_secret` in public clients (SPA/mobile). Use PKCE and keep secrets on the server only.
+
+---
+
+## 🔗 Step 2: Build Authorization URL (with PKCE)
+
+**Authorization endpoint:** `/oauth2/auth`  
+**Method:** `GET`
+
+**Required query params:**
+- `response_type=code`
+- `client_id=YOUR_CLIENT_ID`
+- `redirect_uri=YOUR_REDIRECT_URI` (must match exactly)
+- `scope=openid offline user collection`
+- `state=RANDOM_STRING` (validate on callback; CSRF)
+- `nonce=RANDOM_STRING` (strongly recommended when requesting `openid`; some deployments **require** it. If an ID token is returned, verify the token’s `nonce` claim matches your original value.)
+- `code_challenge=BASE64URL_SHA256(code_verifier)`
+- `code_challenge_method=S256`
+
+**Environment bases**
+- Pre-Production: `https://prelive-oauth2.quran.foundation`
+- Production: `https://oauth2.quran.foundation`
+
+**Example URL (Pre-Production with PKCE):**
+
+```
+https://prelive-oauth2.quran.foundation/oauth2/auth?response_type=code
+&client_id=YOUR_CLIENT_ID
+&redirect_uri=https%3A%2F%2Fyour-app.com%2Foauth%2Fcallback
+&scope=openid%20offline%20user%20collection
+&state=VeimvfgqexjiCoCkRWSGcb333o3a
+&nonce=RANDOM_NONCE_VALUE
+&code_challenge=BASE64URL_SHA256_OF_CODE_VERIFIER
+&code_challenge_method=S256
+```
+
+Least privilege: Add scopes only as you need them.
+
+> Tip: Persist your `code_verifier` server-side (session or secure httpOnly cookie) **before** redirecting to `/oauth2/auth`, then read it on the callback to redeem the `code`.
+
+For example, request `collection` only when the user actually creates or manages a collection.
+
+<details>
+<summary><b>PKCE helpers (Node)</b></summary>
+
+```js
+const crypto = require('crypto');
+
+function base64url(buf) {
+  return buf.toString('base64').replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+}
+
+function generatePkcePair() {
+  const codeVerifier = base64url(crypto.randomBytes(32));
+  const hash = crypto.createHash('sha256').update(codeVerifier).digest();
+  const codeChallenge = base64url(hash);
+  return { codeVerifier, codeChallenge };
+}
+```
+
+</details>
+
+<details>
+<summary><b>PKCE helpers (Python)</b></summary>
+
+```python
+import os, base64, hashlib
+
+def base64url(b: bytes) -> str:
+  return base64.urlsafe_b64encode(b).decode().rstrip('=')
+
+def generate_pkce_pair():
+  code_verifier = base64url(os.urandom(32))
+  code_challenge = base64url(hashlib.sha256(code_verifier.encode()).digest())
+  return code_verifier, code_challenge
+```
+
+</details>
+
+---
+
+## 🔑 Step 3: Exchange Code for Tokens
+
+- Token endpoint: `/oauth2/token`
+- Method: `POST`
+- Public PKCE clients: send `client_id` in the body + `code_verifier`
+- Confidential clients: use HTTP Basic (`client_id:client_secret`)
+
+Expected response includes `access_token`, `refresh_token` (if `offline` scope), `id_token` (if `openid`), `expires_in`.
+
+Note: If you used PKCE in Step 2, always send `code_verifier` here.
+
+<details>
+<summary><b>cURL (confidential client)</b></summary>
+
+```bash
+curl --request POST \
+  --url https://prelive-oauth2.quran.foundation/oauth2/token \
+  --user 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=authorization_code&code=YOUR_CODE&redirect_uri=https%3A%2F%2Fyour-app.com%2Foauth%2Fcallback&code_verifier=YOUR_CODE_VERIFIER'
+```
+
+</details>
+
+<details>
+<summary><b>cURL (public PKCE client)</b></summary>
+
+```bash
+curl --request POST \
+  --url https://prelive-oauth2.quran.foundation/oauth2/token \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=authorization_code&client_id=YOUR_CLIENT_ID&code=YOUR_CODE&redirect_uri=https%3A%2F%2Fyour-app.com%2Foauth%2Fcallback&code_verifier=YOUR_CODE_VERIFIER'
+```
+
+</details>
+
+<details>
+<summary><b>JavaScript (Node, axios — public PKCE)</b></summary>
+
+```js
+const axios = require('axios');
+
+async function exchangeCodeForTokens(clientId, code, redirectUri, codeVerifier) {
+  const params = new URLSearchParams();
+  params.append('grant_type', 'authorization_code');
+  params.append('client_id', clientId);
+  params.append('code', code);
+  params.append('redirect_uri', redirectUri);
+  params.append('code_verifier', codeVerifier);
+
+  const res = await axios.post(
+    'https://prelive-oauth2.quran.foundation/oauth2/token',
+    params.toString(),
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+  );
+  return res.data;
+}
+```
+
+</details>
+
+<details>
+<summary><b>Python (requests — public PKCE)</b></summary>
+
+```python
+import requests
+
+def exchange_code_for_tokens(client_id, code, redirect_uri, code_verifier):
+    resp = requests.post(
+        'https://prelive-oauth2.quran.foundation/oauth2/token',
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        data={
+            'grant_type': 'authorization_code',
+            'client_id': client_id,
+            'code': code,
+            'redirect_uri': redirect_uri,
+            'code_verifier': code_verifier,
+        },
+    )
+    return resp.json()
+```
+
+</details>
+
+Sample token response
+
+```json
+{
+  "access_token": "ACCESS_TOKEN",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "REFRESH_TOKEN_IF_OFFLINE_SCOPE",
+  "id_token": "JWT_IF_OPENID_SCOPE",
+  "scope": "openid offline user collection"
+}
+```
+
+### Verify granted scopes
+After the token exchange, compare the `scope` field in the token response with the features your app intends to enable; hide or disable any feature whose scope wasn’t granted.
+
+---
+
+## 🟢 Step 4: Call User APIs with Headers
+
+Include the token and your client ID in request headers:
+
+```http
+x-auth-token: YOUR_ACCESS_TOKEN
+x-client-id: YOUR_CLIENT_ID
+```
+
+<details>
+<summary><b>cURL — Get collections</b></summary>
+
+```bash
+curl --request GET \
+  --url https://apis-prelive.quran.foundation/auth/v1/collections \
+  --header "x-auth-token: YOUR_ACCESS_TOKEN" \
+  --header "x-client-id: YOUR_CLIENT_ID"
+```
+
+</details>
+
+ 
+
+<details>
+<summary><b>JavaScript (Node)</b></summary>
+
+```js
+const axios = require('axios');
+
+async function getCollections(accessToken, clientId) {
+  const res = await axios.get(
+    'https://apis-prelive.quran.foundation/auth/v1/collections',
+    { headers: { 'x-auth-token': accessToken, 'x-client-id': clientId } }
+  );
+  return res.data;
+}
+```
+
+</details>
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+import requests
+
+def get_collections(access_token, client_id):
+    r = requests.get(
+        'https://apis-prelive.quran.foundation/auth/v1/collections',
+        headers={'x-auth-token': access_token, 'x-client-id': client_id}
+    )
+    return r.json()
+```
+
+</details>
+
+---
+
+## 🔁 Step 5: Refresh the Access Token (offline scope)
+
+When `expires_in` elapses, exchange the `refresh_token` for a new `access_token`.
+
+<details>
+<summary><b>cURL (confidential)</b></summary>
+
+```bash
+curl --request POST \
+  --url https://prelive-oauth2.quran.foundation/oauth2/token \
+  --user 'YOUR_CLIENT_ID:YOUR_CLIENT_SECRET' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=refresh_token&refresh_token=YOUR_REFRESH_TOKEN'
+```
+
+</details>
+
+<details>
+<summary><b>cURL (public PKCE)</b></summary>
+
+```bash
+curl --request POST \
+  --url https://prelive-oauth2.quran.foundation/oauth2/token \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=refresh_token&client_id=YOUR_CLIENT_ID&refresh_token=YOUR_REFRESH_TOKEN'
+```
+
+</details>
+
+<details>
+<summary><b>JavaScript (Node)</b></summary>
+
+```js
+const axios = require('axios');
+
+async function refreshAccessToken(clientId, clientSecret, refreshToken) {
+  const params = new URLSearchParams();
+  params.append('grant_type', 'refresh_token');
+  params.append('refresh_token', refreshToken);
+
+  const res = await axios.post(
+    'https://prelive-oauth2.quran.foundation/oauth2/token',
+    params.toString(),
+    {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      auth: { username: clientId, password: clientSecret }
+    }
+  );
+  return res.data;
+}
+```
+
+</details>
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+import requests
+
+def refresh_access_token(client_id, client_secret, refresh_token):
+    resp = requests.post(
+        'https://prelive-oauth2.quran.foundation/oauth2/token',
+        auth=(client_id, client_secret),
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        data={'grant_type': 'refresh_token', 'refresh_token': refresh_token}
+    )
+    return resp.json()
+```
+
+</details>
+
+---
+
+## ⚠️ Important Considerations
+
+- Redirect URIs: Must match exactly (including scheme, host, path, and trailing slash).
+- State: Always send and validate `state` to protect against CSRF.
+- Nonce: When you request `openid`, always include a `nonce`. Some deployments enforce it; if an ID token is issued, you **must** verify the `nonce` claim equals the value you initially sent.
+- PKCE: Use for public clients (SPAs/mobile). Do not ship `client_secret` to browsers/mobile apps.
+- Scopes: Use `openid offline user collection`. Add more scopes only as needed.
+- Scopes note: Quran.Foundation expects `offline` (not `offline_access`).
+- Token storage: Store `refresh_token` securely; rotate if compromised.
+- Clock skew: Ensure system time is correct (e.g., via NTP) to avoid `invalid_grant` due to time drift.
+
+> 🚩 Do not mix tokens across environments. A token from Pre-Production will not work on Production, and vice versa.
+
+| Environment    | Auth URL                                  | API Base URL                            | Usage                 |
+| -------------- | ----------------------------------------- | --------------------------------------- | --------------------- |
+| Pre-Production | `https://prelive-oauth2.quran.foundation` | `https://apis-prelive.quran.foundation` | Testing & development |
+| Production     | `https://oauth2.quran.foundation`         | `https://apis.quran.foundation`         | Live applications     |
+
+---
+
+## ❌ Common Issues & Troubleshooting
+
+| Error                      | Likely Cause                                 | Resolution |
+| -------------------------- | -------------------------------------------- | ---------- |
+| `invalid_client`          | Wrong client credentials                      | Verify `client_id/secret`, environment |
+| `invalid_grant`           | Bad/expired/used `code` or `refresh_token`   | Ensure one-time use, check clock skew |
+| `redirect_uri_mismatch`   | Redirect URI not exact match                 | Align with registered value |
+| `invalid_scope`           | Scope misspelled or not allowed              | Use valid scopes; request incrementally |
+| `401 Unauthorized` (APIs) | Missing/expired token                         | Send `x-auth-token` and `x-client-id`, refresh token |


### PR DESCRIPTION
### Summary
This PR fully rewrites the OAuth 2.0 documentation for Quran.Foundation APIs to be clearer, developer-friendly, and aligned with our Quick Start style.  
The new guide emphasizes Authorization Code + PKCE for User APIs, while distinguishing it from Client Credentials for Content APIs.

### Key changes
- Reorganized guide into 5 clear steps (client credentials → build auth URL → token exchange → API call → refresh).
- Added ready-to-run code examples:
  - Node.js (axios) + Python (requests)
  - PKCE helper snippets for generating code_verifier/code_challenge
- Included example cURL commands for confidential and public clients.
- Added sample token response and guidance on scope verification.
- Clarified environment base URLs (Pre-Production vs Production).
- Documented important considerations: redirect URI matching, state/nonce, scope usage, token storage, PKCE rules.
- Added a troubleshooting section with common errors and resolutions.

### Motivation
The old guide was abstract and difficult to follow. This version:
- Uses a step-by-step format with concrete code.
- Reduces developer friction by providing drop-in snippets.
- Prevents common pitfalls by documenting known issues upfront.
