### PR TITLE
[codex] Rework docs navigation into a versionless QF sidebar and promote user quickstarts

### DIFF
--- a/docs/api/field-reference.mdx
+++ b/docs/api/field-reference.mdx
@@ -2,6 +2,7 @@
 id: field-reference
 title: Field Reference
 sidebar_label: Field Reference
+displayed_sidebar: APIsSidebar
 ---
 
 ## 📘 Verse-Level Fields (`fields`) {#verse-level-fields}

--- a/docs/content_apis_versioned/4.0.0/audio-reciter-lookup.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/audio-reciter-lookup.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Find the closest verse timing segment for 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/audio-reciter-timestamp.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/audio-reciter-timestamp.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Find the timestamp range for a reciter's a
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/chapter-info.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/chapter-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get list of chapter info we've in diff
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/chapter-reciter-audio-file.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/chapter-reciter-audio-file.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get chapter's audio file of a reciter. Sup
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/chapter-reciter-audio-files.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/chapter-reciter-audio-files.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of chapters' audio files of a rec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/chapter-reciters.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/chapter-reciters.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of Chapter Reciter.","operationId
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/content-apis.info.mdx
+++ b/docs/content_apis_versioned/4.0.0/content-apis.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/content_apis_versioned/4.0.0/get-chapter-info.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-chapter-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Chapters"],"description":"Get Chapter Info in specific language. 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-chapter.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-chapter.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Chapters"],"description":"Get details of a single Chapter.","oper
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-foot-note.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-foot-note.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Footnote"],"description":"Retrieve a single footnote.","operation
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-hizb.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-hizb.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Hizb"],"description":"Get details for a single Hizb.","operationI
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-juz.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-juz.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Juz"],"description":"Get details for a single Juz.","operationId"
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-manzil.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-manzil.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Manzil"],"description":"Get details for a single Manzil.","operat
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-rub-el-hizb.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-rub-el-hizb.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Rub El Hizb"],"description":"Get details for a single Rub ø al-·∏
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/get-ruku.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/get-ruku.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Ruku"],"description":"Get details for a single Ruku.","operationI
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/languages.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/languages.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get all languages. You can get transla
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-ayah-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-ayah-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a specific 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-ayah-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-ayah-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Ayah.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-ayah-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-ayah-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-chapters.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-chapters.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Chapters"],"description":"Get list of Chapter. When a `language` 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-hizb-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-hizb-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a Hizb.","o
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-hizb-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-hizb-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Hizb.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-hizb-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-hizb-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-hizbs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-hizbs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Hizb"],"description":"Get list of all Hizbs with verse boundaries
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-juz-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-juz-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a juz.","op
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-juz-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-juz-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Juz."
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-juz-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-juz-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-juzs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-juzs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Juz"],"description":"Get list of all Juzs with verse boundaries."
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-manzil-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-manzil-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah recitations for a Manzil.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-manzil-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-manzil-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Manzi
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-manzil-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-manzil-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-manzils.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-manzils.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Manzil"],"description":"Get list of all Manzils.","operationId":"
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-page-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-page-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a Madani Mu
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-page-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-page-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Madan
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-page-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-page-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a Rub el Hi
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Rub e
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-rub-el-hizbs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-rub-el-hizbs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Rub El Hizb"],"description":"Get list of all Rubʿ al-Ḥizb segm
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-ruku-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-ruku-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah recitations for a Ruku.",
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-ruku-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-ruku-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Ruku.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-ruku-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-ruku-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-rukus.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-rukus.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Ruku"],"description":"Get list of all Rukus.","operationId":"list
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-surah-recitation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-surah-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Returns per-verse audio file URLs for the 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-surah-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-surah-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Surah
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/list-surah-translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/list-surah-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/posts-controller-feed.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/posts-controller-feed.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_feed","description":"Retrieve a paginated f
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/posts-controller-find-one.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/posts-controller-find-one.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_findOne","description":"Retrieve a specific
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/posts-controller-get-all-comment.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/posts-controller-get-all-comment.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getAllComment","description":"Retrieve all 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/posts-controller-get-comments.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/posts-controller-get-comments.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getComments","description":"Retrieve pagina
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/posts-controller-get-user-post.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/posts-controller-get-user-post.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getUserPost","description":"Retrieve public
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-by-script.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-by-script.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Stream the complete Quran text in the requ
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-code-v-1.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-code-v-1.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get glyph codes of ayah for QCF v1 font","
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-code-v-2.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-code-v-2.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get glyph codes of ayah for QCF v2 font","
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-imlaei.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-imlaei.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Imlaei simple script(without tashkiq/d
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-indopak-nastaleeq.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-indopak-nastaleeq.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Indopak Nastaleeq script of ayah. Use 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-indopak.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-indopak.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Indopak script of ayah. Use query stri
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-uthmani-simple.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-uthmani-simple.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Uthmani simple script(without tashkiq/
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-uthmani-tajweed.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-uthmani-tajweed.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Uthmani color coded tajweed text of ay
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/quran-verses-uthmani.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/quran-verses-uthmani.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Uthmani script of ayah. Use query stri
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/random-verse.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/random-verse.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get a random verse. You can get random ve
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/recitation-audio-files.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/recitation-audio-files.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of AudioFile for a single recitat
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/recitation-info.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/recitation-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get information of a specific recitati
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/recitation-styles.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/recitation-styles.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get the available recitation styles.",
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/recitations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/recitations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of available Recitations.","opera
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/tafsir-info.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/tafsir-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get the information of a specific tafs
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/tafsir.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/tafsir.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get a single Tafsir of all ayah.\n\nSee [/
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/tafsirs.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get list of available tafsirs.","opera
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/translation-info.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/translation-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get information of a specific translat
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/translation.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/translation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get a single Translation of all ayah.\n\nS
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/translations.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get list of available translations. Us
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verse-media.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verse-media.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get media related to the verse.","oper
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-chapter-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-chapter-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get list of Verse(s) by Chapter / Surah n
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-hizb-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-hizb-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses from a specific Hizb( half
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-juz-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-juz-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses from a specific juz(1-30).
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-manzil-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-manzil-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses from a specific manzil (1-
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-page-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-page-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses of a specific Madani Musha
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-range.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-range.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get verses within a verse key range. Both
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-rub-el-hizb-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-rub-el-hizb-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses of a specific Rub el Hizb 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-ruku-number.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-ruku-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses in a specific ruku (1-558)
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/4.0.0/verses-by-verse-key.api.mdx
+++ b/docs/content_apis_versioned/4.0.0/verses-by-verse-key.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get a specific ayah with key. Key is comb
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/4.0.0/content-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/audio-reciter-lookup.api.mdx
+++ b/docs/content_apis_versioned/audio-reciter-lookup.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Find the closest verse timing segment for 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/audio-reciter-timestamp.api.mdx
+++ b/docs/content_apis_versioned/audio-reciter-timestamp.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Find the timestamp range for a reciter's a
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/chapter-info.api.mdx
+++ b/docs/content_apis_versioned/chapter-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get list of chapter info we've in diff
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/chapter-reciter-audio-file.api.mdx
+++ b/docs/content_apis_versioned/chapter-reciter-audio-file.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get chapter's audio file of a reciter. Sup
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/chapter-reciter-audio-files.api.mdx
+++ b/docs/content_apis_versioned/chapter-reciter-audio-files.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of chapters' audio files of a rec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/chapter-reciters.api.mdx
+++ b/docs/content_apis_versioned/chapter-reciters.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of Chapter Reciter.","operationId
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/content-apis.info.mdx
+++ b/docs/content_apis_versioned/content-apis.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/content_apis_versioned/get-chapter-info.api.mdx
+++ b/docs/content_apis_versioned/get-chapter-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Chapters"],"description":"Get Chapter Info in specific language. 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-chapter.api.mdx
+++ b/docs/content_apis_versioned/get-chapter.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Chapters"],"description":"Get details of a single Chapter.","oper
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-foot-note.api.mdx
+++ b/docs/content_apis_versioned/get-foot-note.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Footnote"],"description":"Retrieve a single footnote.","operation
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-hizb.api.mdx
+++ b/docs/content_apis_versioned/get-hizb.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Hizb"],"description":"Get details for a single Hizb.","operationI
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-juz.api.mdx
+++ b/docs/content_apis_versioned/get-juz.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Juz"],"description":"Get details for a single Juz.","operationId"
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-manzil.api.mdx
+++ b/docs/content_apis_versioned/get-manzil.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Manzil"],"description":"Get details for a single Manzil.","operat
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-rub-el-hizb.api.mdx
+++ b/docs/content_apis_versioned/get-rub-el-hizb.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Rub El Hizb"],"description":"Get details for a single Rub ø al-·∏
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/get-ruku.api.mdx
+++ b/docs/content_apis_versioned/get-ruku.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Ruku"],"description":"Get details for a single Ruku.","operationI
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/languages.api.mdx
+++ b/docs/content_apis_versioned/languages.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get all languages. You can get transla
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-ayah-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-ayah-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a specific 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-ayah-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-ayah-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Ayah.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-ayah-translations.api.mdx
+++ b/docs/content_apis_versioned/list-ayah-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-chapters.api.mdx
+++ b/docs/content_apis_versioned/list-chapters.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Chapters"],"description":"Get list of Chapter. When a `language` 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-hizb-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-hizb-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a Hizb.","o
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-hizb-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-hizb-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Hizb.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-hizb-translations.api.mdx
+++ b/docs/content_apis_versioned/list-hizb-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-hizbs.api.mdx
+++ b/docs/content_apis_versioned/list-hizbs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Hizb"],"description":"Get list of all Hizbs with verse boundaries
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-juz-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-juz-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a juz.","op
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-juz-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-juz-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Juz."
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-juz-translations.api.mdx
+++ b/docs/content_apis_versioned/list-juz-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-juzs.api.mdx
+++ b/docs/content_apis_versioned/list-juzs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Juz"],"description":"Get list of all Juzs with verse boundaries."
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-manzil-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-manzil-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah recitations for a Manzil.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-manzil-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-manzil-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Manzi
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-manzil-translations.api.mdx
+++ b/docs/content_apis_versioned/list-manzil-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-manzils.api.mdx
+++ b/docs/content_apis_versioned/list-manzils.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Manzil"],"description":"Get list of all Manzils.","operationId":"
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-page-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-page-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a Madani Mu
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-page-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-page-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Madan
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-page-translations.api.mdx
+++ b/docs/content_apis_versioned/list-page-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-rub-el-hizb-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-rub-el-hizb-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah AudioFile for a Rub el Hi
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-rub-el-hizb-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-rub-el-hizb-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Rub e
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-rub-el-hizb-translations.api.mdx
+++ b/docs/content_apis_versioned/list-rub-el-hizb-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-rub-el-hizbs.api.mdx
+++ b/docs/content_apis_versioned/list-rub-el-hizbs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Rub El Hizb"],"description":"Get list of all Rubʿ al-Ḥizb segm
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-ruku-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-ruku-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of ayah recitations for a Ruku.",
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-ruku-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-ruku-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Ruku.
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-ruku-translations.api.mdx
+++ b/docs/content_apis_versioned/list-ruku-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-rukus.api.mdx
+++ b/docs/content_apis_versioned/list-rukus.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Ruku"],"description":"Get list of all Rukus.","operationId":"list
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-surah-recitation.api.mdx
+++ b/docs/content_apis_versioned/list-surah-recitation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Returns per-verse audio file URLs for the 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-surah-tafsirs.api.mdx
+++ b/docs/content_apis_versioned/list-surah-tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Tafsirs"],"description":"Get list of tafsirs for a specific Surah
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/list-surah-translations.api.mdx
+++ b/docs/content_apis_versioned/list-surah-translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Translations"],"description":"Get list of translations for a spec
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/posts-controller-feed.api.mdx
+++ b/docs/content_apis_versioned/posts-controller-feed.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_feed","description":"Retrieve a paginated f
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/posts-controller-find-one.api.mdx
+++ b/docs/content_apis_versioned/posts-controller-find-one.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_findOne","description":"Retrieve a specific
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/posts-controller-get-all-comment.api.mdx
+++ b/docs/content_apis_versioned/posts-controller-get-all-comment.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getAllComment","description":"Retrieve all 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/posts-controller-get-comments.api.mdx
+++ b/docs/content_apis_versioned/posts-controller-get-comments.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getComments","description":"Retrieve pagina
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/posts-controller-get-user-post.api.mdx
+++ b/docs/content_apis_versioned/posts-controller-get-user-post.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getUserPost","description":"Retrieve public
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-by-script.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-by-script.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Stream the complete Quran text in the requ
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-code-v-1.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-code-v-1.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get glyph codes of ayah for QCF v1 font","
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-code-v-2.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-code-v-2.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get glyph codes of ayah for QCF v2 font","
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-imlaei.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-imlaei.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Imlaei simple script(without tashkiq/d
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-indopak-nastaleeq.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-indopak-nastaleeq.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Indopak Nastaleeq script of ayah. Use 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-indopak.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-indopak.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Indopak script of ayah. Use query stri
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-uthmani-simple.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-uthmani-simple.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Uthmani simple script(without tashkiq/
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-uthmani-tajweed.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-uthmani-tajweed.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Uthmani color coded tajweed text of ay
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/quran-verses-uthmani.api.mdx
+++ b/docs/content_apis_versioned/quran-verses-uthmani.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get Uthmani script of ayah. Use query stri
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/random-verse.api.mdx
+++ b/docs/content_apis_versioned/random-verse.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get a random verse. You can get random ve
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/recitation-audio-files.api.mdx
+++ b/docs/content_apis_versioned/recitation-audio-files.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of AudioFile for a single recitat
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/recitation-info.api.mdx
+++ b/docs/content_apis_versioned/recitation-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get information of a specific recitati
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/recitation-styles.api.mdx
+++ b/docs/content_apis_versioned/recitation-styles.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get the available recitation styles.",
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/recitations.api.mdx
+++ b/docs/content_apis_versioned/recitations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Audio"],"description":"Get list of available Recitations.","opera
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/tafsir-info.api.mdx
+++ b/docs/content_apis_versioned/tafsir-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get the information of a specific tafs
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/tafsir.api.mdx
+++ b/docs/content_apis_versioned/tafsir.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get a single Tafsir of all ayah.\n\nSee [/
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/tafsirs.api.mdx
+++ b/docs/content_apis_versioned/tafsirs.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get list of available tafsirs.","opera
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/translation-info.api.mdx
+++ b/docs/content_apis_versioned/translation-info.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get information of a specific translat
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/translation.api.mdx
+++ b/docs/content_apis_versioned/translation.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Quran"],"description":"Get a single Translation of all ayah.\n\nS
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/translations.api.mdx
+++ b/docs/content_apis_versioned/translations.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get list of available translations. Us
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verse-media.api.mdx
+++ b/docs/content_apis_versioned/verse-media.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Resources"],"description":"Get media related to the verse.","oper
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-chapter-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-chapter-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get list of Verse(s) by Chapter / Surah n
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-hizb-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-hizb-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses from a specific Hizb( half
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-juz-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-juz-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses from a specific juz(1-30).
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-manzil-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-manzil-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses from a specific manzil (1-
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-page-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-page-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses of a specific Madani Musha
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-range.api.mdx
+++ b/docs/content_apis_versioned/verses-by-range.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get verses within a verse key range. Both
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-rub-el-hizb-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-rub-el-hizb-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses of a specific Rub el Hizb 
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-ruku-number.api.mdx
+++ b/docs/content_apis_versioned/verses-by-ruku-number.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get all verses in a specific ruku (1-558)
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/content_apis_versioned/verses-by-verse-key.api.mdx
+++ b/docs/content_apis_versioned/verses-by-verse-key.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Verses"],"description":"Get a specific ayah with key. Key is comb
 sidebar_class_name: "get api-method"
 info_path: docs/content_apis_versioned/content-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/1.0.0/get-oidc-user-info.api.mdx
+++ b/docs/oauth2_apis_versioned/1.0.0/get-oidc-user-info.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint returns the payload of the ID Token, includin
 sidebar_class_name: "get api-method"
 info_path: docs/oauth2_apis_versioned/1.0.0/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/1.0.0/introspect-o-auth-2-token.api.mdx
+++ b/docs/oauth2_apis_versioned/1.0.0/introspect-o-auth-2-token.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"The introspection endpoint allows to check if a token (both
 sidebar_class_name: "post api-method"
 info_path: docs/oauth2_apis_versioned/1.0.0/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/1.0.0/o-auth-2-authorize.api.mdx
+++ b/docs/oauth2_apis_versioned/1.0.0/o-auth-2-authorize.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint is used to start the authorization process. T
 sidebar_class_name: "get api-method"
 info_path: docs/oauth2_apis_versioned/1.0.0/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/1.0.0/oauth-2-apis.info.mdx
+++ b/docs/oauth2_apis_versioned/1.0.0/oauth-2-apis.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/oauth2_apis_versioned/1.0.0/oauth-2-token-exchange.api.mdx
+++ b/docs/oauth2_apis_versioned/1.0.0/oauth-2-token-exchange.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint is used by your application to obtain an acce
 sidebar_class_name: "post api-method"
 info_path: docs/oauth2_apis_versioned/1.0.0/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/1.0.0/revoke-oidc-session.api.mdx
+++ b/docs/oauth2_apis_versioned/1.0.0/revoke-oidc-session.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint handles the user logout process in Quran.Foun
 sidebar_class_name: "get api-method"
 info_path: docs/oauth2_apis_versioned/1.0.0/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/get-oidc-user-info.api.mdx
+++ b/docs/oauth2_apis_versioned/get-oidc-user-info.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint returns the payload of the ID Token, includin
 sidebar_class_name: "get api-method"
 info_path: docs/oauth2_apis_versioned/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/introspect-o-auth-2-token.api.mdx
+++ b/docs/oauth2_apis_versioned/introspect-o-auth-2-token.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"The introspection endpoint allows to check if a token (both
 sidebar_class_name: "post api-method"
 info_path: docs/oauth2_apis_versioned/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/o-auth-2-authorize.api.mdx
+++ b/docs/oauth2_apis_versioned/o-auth-2-authorize.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint is used to start the authorization process. T
 sidebar_class_name: "get api-method"
 info_path: docs/oauth2_apis_versioned/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/oauth-2-apis.info.mdx
+++ b/docs/oauth2_apis_versioned/oauth-2-apis.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/oauth2_apis_versioned/oauth-2-token-exchange.api.mdx
+++ b/docs/oauth2_apis_versioned/oauth-2-token-exchange.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint is used by your application to obtain an acce
 sidebar_class_name: "post api-method"
 info_path: docs/oauth2_apis_versioned/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/oauth2_apis_versioned/revoke-oidc-session.api.mdx
+++ b/docs/oauth2_apis_versioned/revoke-oidc-session.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"This endpoint handles the user logout process in Quran.Foun
 sidebar_class_name: "get api-method"
 info_path: docs/oauth2_apis_versioned/oauth-2-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -1,12 +1,13 @@
 ﻿---
 id: index
-title: 🚀 Quick Start Guide
-sidebar_label: Quick Start
+title: Content APIs Quickstart Guide
+sidebar_label: Content APIs Quickstart
+displayed_sidebar: APIsSidebar
 ---
 
-# 🚀 Quick Start Guide
+# Content APIs Quickstart Guide
 
-Welcome to the Quran Foundation API! This Quick Start guide will help you get up and running within minutes.
+Welcome to the Quran Foundation API! This Content APIs Quickstart Guide will help you get up and running within minutes.
 
 :::tip Recommended for first-time users
 Follow these steps to make your first successful API call.
@@ -1193,7 +1194,7 @@ Now that you're authenticated and have successfully made your first API call, ex
 ## 🤖 Complete Implementation Prompt
 
 ```text
-Implement the full Quick Start flow end-to-end in this codebase with minimal assumptions.
+Implement the full Content APIs Quickstart flow end-to-end in this codebase with minimal assumptions.
 
 RECOMMENDED: Use the official SDK (TypeScript/JavaScript)
 For TypeScript/JavaScript projects, install @quranjs/api which handles token management,
@@ -1245,7 +1246,7 @@ Client-side (rules)
   - translate="no" on Quranic text containers (and optionally class="notranslate")
 
 Constraints
-- Use the Quick Start guide at https://api-docs.quran.foundation/docs/quickstart/ as the source of truth for URLs, headers, and endpoint paths.
+- Use the Content APIs Quickstart Guide at https://api-docs.quran.foundation/docs/quickstart/ as the source of truth for URLs, headers, and endpoint paths.
 - Do not invent endpoints or headers; copy them exactly.
 - Remember: Client Credentials has NO refresh_token - re-request tokens, don't try to refresh.
 

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -34,4 +34,4 @@ Our SDKs provide:
 
 ## Direct API Access
 
-If you prefer to use the API directly without an SDK, check out our [Quick Start Guide](/docs/quickstart) and [API Reference](/docs/category/content-apis).
+If you prefer to use the API directly without an SDK, check out our [Content APIs Quickstart Guide](/docs/quickstart) and [API Reference](/docs/category/content-apis).

--- a/docs/search_apis_versioned/1.0.0/quran-foundation-search-api.info.mdx
+++ b/docs/search_apis_versioned/1.0.0/quran-foundation-search-api.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/search_apis_versioned/1.0.0/search-controller-search.api.mdx
+++ b/docs/search_apis_versioned/1.0.0/search-controller-search.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"SearchController_search","description":"\nSearch for verses
 sidebar_class_name: "get api-method"
 info_path: docs/search_apis_versioned/1.0.0/quran-foundation-search-api
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/search_apis_versioned/1.0.0/search.tag.mdx
+++ b/docs/search_apis_versioned/1.0.0/search.tag.mdx
@@ -3,7 +3,7 @@ id: search
 title: "Search"
 description: "Search"
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 

--- a/docs/search_apis_versioned/quran-foundation-search-api.info.mdx
+++ b/docs/search_apis_versioned/quran-foundation-search-api.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/search_apis_versioned/search-controller-search.api.mdx
+++ b/docs/search_apis_versioned/search-controller-search.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"SearchController_search","description":"\nSearch for verses
 sidebar_class_name: "get api-method"
 info_path: docs/search_apis_versioned/quran-foundation-search-api
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/search_apis_versioned/search.tag.mdx
+++ b/docs/search_apis_versioned/search.tag.mdx
@@ -3,7 +3,7 @@ id: search
 title: "Search"
 description: "Search"
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 

--- a/docs/tutorials/faq.mdx
+++ b/docs/tutorials/faq.mdx
@@ -3,6 +3,7 @@ id: faq
 title: Frequently Asked Questions
 sidebar_label: FAQ
 sidebar_position: 0
+displayed_sidebar: APIsSidebar
 ---
 
 # Frequently Asked Questions
@@ -11,7 +12,7 @@ This FAQ answers common questions developers have when working with Quran.Founda
 
 ## Why should I block automatic translation on Quran text returned by the API?
 
-The API already delivers peer-reviewed translations. Auto-translating them can distort meaning and create theological inaccuracies. Disable auto-translation using the HTML/CSP techniques linked in the Quick Start guide.
+The API already delivers peer-reviewed translations. Auto-translating them can distort meaning and create theological inaccuracies. Disable auto-translation using the HTML/CSP techniques linked in the [Content APIs Quickstart Guide](/docs/quickstart).
 
 ## How do I obtain OAuth2 credentials?
 

--- a/docs/tutorials/fonts/font-rendering.md
+++ b/docs/tutorials/fonts/font-rendering.md
@@ -1,3 +1,7 @@
+---
+displayed_sidebar: APIsSidebar
+---
+
 # Integrating Quran Font Rendering
 
 ## Overview
@@ -149,7 +153,7 @@ Quran.com supports two categories of fonts:
 
 ## API Parameters for Font Rendering
 
-This section covers the specific API parameters needed for font rendering. For complete API documentation including authentication, endpoints, and general usage, see the [Quick Start Guide](https://api-docs.quran.foundation/docs/quickstart).
+This section covers the specific API parameters needed for font rendering. For complete API documentation including authentication, endpoints, and general usage, see the [Content APIs Quickstart Guide](/docs/quickstart).
 
 ### Essential Parameters
 

--- a/docs/tutorials/fonts/page-layout.md
+++ b/docs/tutorials/fonts/page-layout.md
@@ -1,3 +1,7 @@
+---
+displayed_sidebar: APIsSidebar
+---
+
 # Page Layout API Guide
 
 ## Introduction

--- a/docs/tutorials/oidc/client-setup.mdx
+++ b/docs/tutorials/oidc/client-setup.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+displayed_sidebar: APIsSidebar
 ---
 
 # OAuth2 Client Configuration

--- a/docs/tutorials/oidc/example-integration.mdx
+++ b/docs/tutorials/oidc/example-integration.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+displayed_sidebar: APIsSidebar
 ---
 
 # OAuth2 Web Integration Example
@@ -233,5 +234,5 @@ fly deploy
 ## Next Steps
 
 - **[Full OAuth2 Guide](/docs/tutorials/oidc/getting-started-with-oauth2)** — Detailed walkthrough with AI prompts
-- **[Mobile Apps](/docs/category/mobile-apps)** — iOS, Android, React Native guides
+- **[Mobile Apps](/docs/tutorials/oidc/mobile-apps)** — iOS, Android, React Native guides
 - **[User APIs Reference](/docs/category/user-related-apis)** — All available endpoints

--- a/docs/tutorials/oidc/getting-started-with-oauth2.mdx
+++ b/docs/tutorials/oidc/getting-started-with-oauth2.mdx
@@ -1,10 +1,11 @@
 ---
 sidebar_position: 1
+displayed_sidebar: APIsSidebar
 ---
 
 # Using OAuth 2.0 to Access Quran.Foundation APIs
 
-Quran.Foundation **User APIs** use the OAuth 2.0 **Authorization Code** flow with **PKCE** for authenticating users and authorizing access to their data. This guide mirrors our Quick Start style: clear steps, tips, and ready-to-run examples in Python (requests) and JavaScript (Node + axios).
+Quran.Foundation **User Related APIs** use the OAuth 2.0 **Authorization Code** flow with **PKCE** for authenticating users and authorizing access to their data. This guide mirrors our quickstart style: clear steps, tips, and ready-to-run examples in Python (requests) and JavaScript (Node + axios).
 
 For identity details (ID token), see [OpenID Connect](/docs/tutorials/oidc/openid-connect).
 
@@ -14,7 +15,7 @@ This guide walks you through OAuth2 Authorization Code flow step-by-step.
 🤖 **Using AI to code?** Look for the <b>"🤖 AI prompt"</b> sections throughout this guide — copy-paste them into ChatGPT, Claude, or Copilot for instant implementation help!
 :::
 
-> 🔀 Flow split: Use **Client Credentials** for **Content APIs** (see [Quick Start](/docs/quickstart)). Use **Authorization Code (+PKCE)** for **User APIs** (this page).
+> 🔀 Flow split: Use **Client Credentials** for **Content APIs** (see [Content APIs Quickstart Guide](/docs/quickstart)). Use **Authorization Code (+PKCE)** for **User Related APIs** (this page).
 
 ---
 
@@ -194,7 +195,7 @@ sequenceDiagram
     Auth-->>App: New access_token and refresh_token
 ```
 
-> 🔧 **Ready to code?** Check out the [User APIs Quick Start](/docs/tutorials/oidc/user-apis-quickstart) for copy-paste examples, or see the [Web Integration Example](/docs/tutorials/oidc/example-integration) and the [hosted demo](https://oauth2-client-prelive.quran.foundation/).
+> 🔧 **Ready to code?** Check out the [User Related APIs Quickstart Guide](/docs/tutorials/oidc/user-apis-quickstart) for copy-paste examples, or see the [Web Integration Example](/docs/tutorials/oidc/example-integration) and the [hosted demo](https://oauth2-client-prelive.quran.foundation/).
 
 ---
 

--- a/docs/tutorials/oidc/mobile-apps/_intro.mdx
+++ b/docs/tutorials/oidc/mobile-apps/_intro.mdx
@@ -8,4 +8,4 @@
 [Learn more about the benefits →](/docs/tutorials/oidc/getting-started-with-oauth2#-why-use-quran-foundation-authentication)
 :::
 
-Please make sure you read our [OAuth2 Quick Start](/docs/tutorials/oidc/user-apis-quickstart) or the [full integration guide](/docs/tutorials/oidc/getting-started-with-oauth2).
+Please make sure you read our [User Related APIs Quickstart Guide](/docs/tutorials/oidc/user-apis-quickstart) or the [full integration guide](/docs/tutorials/oidc/getting-started-with-oauth2).

--- a/docs/tutorials/oidc/mobile-apps/android.mdx
+++ b/docs/tutorials/oidc/mobile-apps/android.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+displayed_sidebar: APIsSidebar
 ---
 import PartialObtainClientCredentials from './_obtain_client_credentials.mdx';
 import PartialIntro from './_intro.mdx';

--- a/docs/tutorials/oidc/mobile-apps/iOS.mdx
+++ b/docs/tutorials/oidc/mobile-apps/iOS.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+displayed_sidebar: APIsSidebar
 ---
 import PartialObtainClientCredentials from './_obtain_client_credentials.mdx';
 import PartialIntro from './_intro.mdx';

--- a/docs/tutorials/oidc/mobile-apps/index.mdx
+++ b/docs/tutorials/oidc/mobile-apps/index.mdx
@@ -1,0 +1,14 @@
+---
+title: Mobile Apps
+displayed_sidebar: APIsSidebar
+---
+
+import PartialIntro from "./_intro.mdx";
+
+# Mobile Apps
+
+<PartialIntro />
+
+- [React Native](/docs/tutorials/oidc/mobile-apps/react-native)
+- [Android](/docs/tutorials/oidc/mobile-apps/android)
+- [iOS](/docs/tutorials/oidc/mobile-apps/iOS)

--- a/docs/tutorials/oidc/mobile-apps/react-native.mdx
+++ b/docs/tutorials/oidc/mobile-apps/react-native.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+displayed_sidebar: APIsSidebar
 ---
 
 import PartialObtainClientCredentials from "./_obtain_client_credentials.mdx";

--- a/docs/tutorials/oidc/openid-connect.mdx
+++ b/docs/tutorials/oidc/openid-connect.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+displayed_sidebar: APIsSidebar
 ---
 
 # OpenID Connect

--- a/docs/tutorials/oidc/user-apis-quickstart.mdx
+++ b/docs/tutorials/oidc/user-apis-quickstart.mdx
@@ -1,12 +1,13 @@
 ---
 sidebar_position: 0
-title: "⚡ User APIs Quick Start"
-sidebar_label: "⚡ Quick Start"
+displayed_sidebar: APIsSidebar
+title: "User Related APIs Quickstart Guide"
+sidebar_label: "User APIs Quickstart"
 ---
 
-# ⚡ User APIs Quick Start
+# User Related APIs Quickstart Guide
 
-Get user authentication working in **under 5 minutes**. This guide shows you the fastest path to integrating Quran Foundation OAuth2 for accessing User APIs (bookmarks, collections, reading progress, etc.).
+Get user authentication working in **under 5 minutes**. This guide shows you the fastest path to integrating Quran Foundation OAuth2 for accessing User Related APIs (bookmarks, collections, reading progress, etc.).
 
 :::tip Recommended for first-time users
 **We've built this for the Ummah so you don't have to.** Use our auth and get cross-app sync with Quran.com for free — while keeping full freedom to build your own features. Link our `user.sub` to your database for custom logic. [Learn more →](/docs/tutorials/oidc/getting-started-with-oauth2#-why-use-quran-foundation-authentication)

--- a/docs/updates/index.md
+++ b/docs/updates/index.md
@@ -2,6 +2,7 @@
 id: index
 title: "📢 API Updates"
 sidebar_label: Updates
+displayed_sidebar: APIsSidebar
 ---
 
 # 📢 Recent API Updates

--- a/docs/user_related_apis_versioned/1.0.0/add-collection-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-collection-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add a bookmark to an existing collection.","tags":["Collect
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/add-collection.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-collection.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Create a new collection under user's account.","tags":["Col
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/add-note.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-note.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Add a new note.","parameters":[],"requestB
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/add-or-update-preference.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-or-update-preference.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add or update one user preferences group like favorite Tafs
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/add-or-update-user-reading-session.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-or-update-user-reading-session.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Track the user's most recent reading location (Surah/Ayah) 
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/add-update-activity-day.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-update-activity-day.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Create or update a daily activity record (one per date per 
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/add-user-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/add-user-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add a bookmark by details.","tags":["Bookmarks"],"parameter
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/bulk-add-or-update-preferences.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/bulk-add-or-update-preferences.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add or update one or more user preferences groups like favo
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/comments-controller-create.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/comments-controller-create.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_create","description":"Add a comment to 
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/comments-controller-delete-comment.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/comments-controller-delete-comment.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_deleteComment","description":"Soft-delet
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/comments-controller-get.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/comments-controller-get.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_get","description":"Retrieve paginated r
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/comments-controller-toggle-like.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/comments-controller-toggle-like.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_toggleLike","description":"Toggle like s
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/create-a-goal.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/create-a-goal.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Create a goal","tags":["Goals"],"parameters":[{"in":"query"
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/delete-a-goal.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/delete-a-goal.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a goal by id.","tags":["Goals"],"parameters":[{"in":
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/delete-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/delete-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a bookmark by id.","tags":["Bookmarks"],"parameters"
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/delete-collection-bookmark-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/delete-collection-bookmark-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a bookmark from an existing collection by bookmark's
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/delete-collection.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/delete-collection.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a an existing collection.","tags":["Collections"],"p
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/delete-note-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/delete-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Delete a note by its ID.","parameters":[{"
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/estimate-reading-time.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/estimate-reading-time.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Estimate the number of seconds it would take to read a rang
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/generate-timeline-estimation.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/generate-timeline-estimation.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Generate a timeline up to a week of the minimum daily amoun
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-activity-days.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-activity-days.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get the user's activity days (calendar/history). Use the `f
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-all-collection-items.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-all-collection-items.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all existing collections along with resources that belo
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-all-collections.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-all-collections.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Collections"],"description":"List collections owned by the user. 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-all-notes.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-all-notes.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"List notes owned by the user. This API con
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-bookmark-collections.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-bookmark-collections.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all collections that a bookmark belongs to by bookmark 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get a bookmark by details","tags":["Bookmarks"],"parameters
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-bookmarks-within-a-range-of-ayahs.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-bookmarks-within-a-range-of-ayahs.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all bookmarks within a specific Ayahs range.","tags":["
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-collection-items-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-collection-items-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all resources that belong to an existing collection by 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-current-streak-days.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-current-streak-days.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get current active streak days.","tags":["Streaks"],"parame
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-note-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve a note by its ID.","parameters":[
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-notes-by-attached-entity.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-notes-by-attached-entity.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve notes by attached entity.","param
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-notes-by-verse-range.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-notes-by-verse-range.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve notes by a range of verses.","par
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-notes-by-verse.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-notes-by-verse.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve notes by a specific verse.","para
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-notes-count-within-verse-range.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-notes-count-within-verse-range.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Get the count of notes within a range of v
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-streaks.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-streaks.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get user streaks.","tags":["Streaks"],"parameters":[{"in":"
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-todays-goal-plan.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-todays-goal-plan.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get today's goal plan.","tags":["Goals"],"parameters":[{"in
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-user-bookmarks.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-user-bookmarks.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all bookmarks. This includes bookmarks belonging to a c
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-user-preferences.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-user-preferences.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all user preferences like theme, favorite reciter, defa
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/get-user-reading-sessions.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/get-user-reading-sessions.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get the user's reading sessions (most recent first). Readin
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-create.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-create.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_create","description":"Create a new post (r
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-delete.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-delete.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_delete","description":"Soft-delete a post b
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-edit.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-edit.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_edit","description":"Update an existing pos
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-export-multiple-posts.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-export-multiple-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_exportMultiplePosts","description":"Generat
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-feed.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-feed.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_feed","description":"Retrieve a paginated f
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-find-one.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-find-one.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_findOne","description":"Retrieve a specific
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-all-comment.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-all-comment.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getAllComment","description":"Retrieve all 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-comments.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-comments.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getComments","description":"Retrieve pagina
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-loggedin-user-posts.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-loggedin-user-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getLoggedinUserPosts","description":"Retrie
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-my-posts-by-verse.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-my-posts-by-verse.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getMyPostsByVerse","description":"Retrieve 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-my-posts-count-within-range.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-my-posts-count-within-range.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getMyPostsCountWithinRange","description":"
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-related-posts.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-related-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getRelatedPosts","description":"Retrieve po
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-get-user-post.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-get-user-post.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getUserPost","description":"Retrieve public
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-report-abuse.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-report-abuse.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_reportAbuse","description":"Report a post f
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-toggle-like.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-toggle-like.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_toggleLike","description":"Toggle like stat
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-toggle-save.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-toggle-save.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_toggleSave","description":"Toggle save/book
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/posts-controller-view-tracking.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/posts-controller-view-tracking.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_viewTracking","description":"Record that a 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/publish-note.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/publish-note.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Publish a note to QR.","parameters":[{"in"
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-accept-by-private-token.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-accept-by-private-token.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_acceptByPrivateToken","description":"Accept
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-accept-invite.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-accept-invite.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_acceptInvite","description":"Accept an invi
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-admins-access.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-admins-access.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_adminsAccess","description":"Grant or revok
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-create-new-group.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-create-new-group.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_createNewGroup","description":"Create a new
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-create-new-page.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-create-new-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_createNewPage","description":"Submit a requ
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-follow-page.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-follow-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_followPage","description":"Follow an organi
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-members.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-members.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomMembers","description":"Retrieve pag
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-posts.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomPosts","description":"Retrieve pagin
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-profile-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-profile-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomProfileById","description":"Retrieve
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-profile.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomProfile","description":"Retrieve a r
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-rooms.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-rooms.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRooms","description":"Retrieve rooms the
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-invite-user-to-room.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-invite-user-to-room.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_inviteUserToRoom","description":"Send an in
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-join-room.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-join-room.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_joinRoom","description":"Join a public grou
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-leave-group.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-leave-group.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_leaveGroup","description":"Leave a group th
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-reject-invite.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-reject-invite.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_rejectInvite","description":"Decline an inv
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-remove-member.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-remove-member.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_removeMember","description":"Remove a user 
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-search-rooms.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-search-rooms.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_searchRooms","description":"Search for publ
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-unfollow-page.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-unfollow-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_unfollowPage","description":"Stop following
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-update-group.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-update-group.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_updateGroup","description":"Update group pr
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-update-page.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-update-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_updatePage","description":"Update page prop
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/rooms-controller-update-post-privacy.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/rooms-controller-update-post-privacy.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_updatePostPrivacy","description":"Change th
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/tags-controller-find.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/tags-controller-find.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"TagsController_find","description":"Search for tags by quer
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/update-a-goal.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/update-a-goal.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Update a goal","tags":["Goals"],"parameters":[{"in":"path",
 sidebar_class_name: "put api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/update-collection.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/update-collection.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Update an existing collection.","tags":["Collections"],"par
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/update-note-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/update-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Update a note by its ID.","parameters":[{"
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/user-related-apis.info.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/user-related-apis.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-delete-account.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-delete-account.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_deleteAccount","description":"Permanently d
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-edit-profile.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-edit-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_editProfile","description":"Partially updat
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-follow-featured-users.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-follow-featured-users.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_followFeaturedUsers","description":"Follows
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-get-featured-users.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-get-featured-users.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getFeaturedUsers","description":"Returns a 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-get-user-followers.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-get-user-followers.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getUserFollowers","description":"Retrieve a
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-get-user-following.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-get-user-following.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getUserFollowing","description":"Retrieve a
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-get-user-profile.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-get-user-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getUserProfile","description":"Retrieve a u
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-profile.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_profile","description":"Retrieve the comple
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-remove-follower.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-remove-follower.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_removeFollower","description":"Remove a use
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-rooms.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-rooms.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_rooms","description":"Retrieve all rooms (g
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-search.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-search.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_search","description":"Search users by name
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-toggle-follow.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-toggle-follow.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_toggleFollow","description":"Follow or unfo
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/1.0.0/users-controller-update-profile.api.mdx
+++ b/docs/user_related_apis_versioned/1.0.0/users-controller-update-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_updateProfile","description":"Update user p
 sidebar_class_name: "put api-method"
 info_path: docs/user_related_apis_versioned/1.0.0/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiVersionedSidebar
+displayed_sidebar: APIsVersionedSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-collection-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/add-collection-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add a bookmark to an existing collection.","tags":["Collect
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-collection.api.mdx
+++ b/docs/user_related_apis_versioned/add-collection.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Create a new collection under user's account.","tags":["Col
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-note.api.mdx
+++ b/docs/user_related_apis_versioned/add-note.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Add a new note.","parameters":[],"requestB
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-or-update-preference.api.mdx
+++ b/docs/user_related_apis_versioned/add-or-update-preference.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add or update one user preferences group like favorite Tafs
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-or-update-user-reading-session.api.mdx
+++ b/docs/user_related_apis_versioned/add-or-update-user-reading-session.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Track the user's most recent reading location (Surah/Ayah) 
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-update-activity-day.api.mdx
+++ b/docs/user_related_apis_versioned/add-update-activity-day.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Create or update a daily activity record (one per date per 
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/add-user-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/add-user-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add a bookmark by details.","tags":["Bookmarks"],"parameter
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/bulk-add-or-update-preferences.api.mdx
+++ b/docs/user_related_apis_versioned/bulk-add-or-update-preferences.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Add or update one or more user preferences groups like favo
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/comments-controller-create.api.mdx
+++ b/docs/user_related_apis_versioned/comments-controller-create.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_create","description":"Add a comment to 
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/comments-controller-delete-comment.api.mdx
+++ b/docs/user_related_apis_versioned/comments-controller-delete-comment.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_deleteComment","description":"Soft-delet
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/comments-controller-get.api.mdx
+++ b/docs/user_related_apis_versioned/comments-controller-get.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_get","description":"Retrieve paginated r
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/comments-controller-toggle-like.api.mdx
+++ b/docs/user_related_apis_versioned/comments-controller-toggle-like.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"CommentsController_toggleLike","description":"Toggle like s
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/create-a-goal.api.mdx
+++ b/docs/user_related_apis_versioned/create-a-goal.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Create a goal","tags":["Goals"],"parameters":[{"in":"query"
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/delete-a-goal.api.mdx
+++ b/docs/user_related_apis_versioned/delete-a-goal.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a goal by id.","tags":["Goals"],"parameters":[{"in":
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/delete-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/delete-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a bookmark by id.","tags":["Bookmarks"],"parameters"
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/delete-collection-bookmark-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/delete-collection-bookmark-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a bookmark from an existing collection by bookmark's
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/delete-collection.api.mdx
+++ b/docs/user_related_apis_versioned/delete-collection.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Delete a an existing collection.","tags":["Collections"],"p
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/delete-note-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/delete-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Delete a note by its ID.","parameters":[{"
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/estimate-reading-time.api.mdx
+++ b/docs/user_related_apis_versioned/estimate-reading-time.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Estimate the number of seconds it would take to read a rang
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/generate-timeline-estimation.api.mdx
+++ b/docs/user_related_apis_versioned/generate-timeline-estimation.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Generate a timeline up to a week of the minimum daily amoun
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-activity-days.api.mdx
+++ b/docs/user_related_apis_versioned/get-activity-days.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get the user's activity days (calendar/history). Use the `f
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-all-collection-items.api.mdx
+++ b/docs/user_related_apis_versioned/get-all-collection-items.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all existing collections along with resources that belo
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-all-collections.api.mdx
+++ b/docs/user_related_apis_versioned/get-all-collections.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Collections"],"description":"List collections owned by the user. 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-all-notes.api.mdx
+++ b/docs/user_related_apis_versioned/get-all-notes.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"List notes owned by the user. This API con
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-bookmark-collections.api.mdx
+++ b/docs/user_related_apis_versioned/get-bookmark-collections.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all collections that a bookmark belongs to by bookmark 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-bookmark.api.mdx
+++ b/docs/user_related_apis_versioned/get-bookmark.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get a bookmark by details","tags":["Bookmarks"],"parameters
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-bookmarks-within-a-range-of-ayahs.api.mdx
+++ b/docs/user_related_apis_versioned/get-bookmarks-within-a-range-of-ayahs.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all bookmarks within a specific Ayahs range.","tags":["
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-collection-items-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/get-collection-items-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all resources that belong to an existing collection by 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-current-streak-days.api.mdx
+++ b/docs/user_related_apis_versioned/get-current-streak-days.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get current active streak days.","tags":["Streaks"],"parame
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-note-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/get-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve a note by its ID.","parameters":[
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-notes-by-attached-entity.api.mdx
+++ b/docs/user_related_apis_versioned/get-notes-by-attached-entity.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve notes by attached entity.","param
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-notes-by-verse-range.api.mdx
+++ b/docs/user_related_apis_versioned/get-notes-by-verse-range.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve notes by a range of verses.","par
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-notes-by-verse.api.mdx
+++ b/docs/user_related_apis_versioned/get-notes-by-verse.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Retrieve notes by a specific verse.","para
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-notes-count-within-verse-range.api.mdx
+++ b/docs/user_related_apis_versioned/get-notes-count-within-verse-range.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Get the count of notes within a range of v
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-streaks.api.mdx
+++ b/docs/user_related_apis_versioned/get-streaks.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get user streaks.","tags":["Streaks"],"parameters":[{"in":"
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-todays-goal-plan.api.mdx
+++ b/docs/user_related_apis_versioned/get-todays-goal-plan.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get today's goal plan.","tags":["Goals"],"parameters":[{"in
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-user-bookmarks.api.mdx
+++ b/docs/user_related_apis_versioned/get-user-bookmarks.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all bookmarks. This includes bookmarks belonging to a c
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-user-preferences.api.mdx
+++ b/docs/user_related_apis_versioned/get-user-preferences.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get all user preferences like theme, favorite reciter, defa
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/get-user-reading-sessions.api.mdx
+++ b/docs/user_related_apis_versioned/get-user-reading-sessions.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Get the user's reading sessions (most recent first). Readin
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-create.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-create.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_create","description":"Create a new post (r
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-delete.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-delete.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_delete","description":"Soft-delete a post b
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-edit.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-edit.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_edit","description":"Update an existing pos
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-export-multiple-posts.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-export-multiple-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_exportMultiplePosts","description":"Generat
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-feed.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-feed.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_feed","description":"Retrieve a paginated f
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-find-one.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-find-one.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_findOne","description":"Retrieve a specific
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-all-comment.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-all-comment.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getAllComment","description":"Retrieve all 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-comments.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-comments.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getComments","description":"Retrieve pagina
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-loggedin-user-posts.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-loggedin-user-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getLoggedinUserPosts","description":"Retrie
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-my-posts-by-verse.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-my-posts-by-verse.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getMyPostsByVerse","description":"Retrieve 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-my-posts-count-within-range.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-my-posts-count-within-range.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getMyPostsCountWithinRange","description":"
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-related-posts.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-related-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getRelatedPosts","description":"Retrieve po
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-get-user-post.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-get-user-post.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_getUserPost","description":"Retrieve public
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-report-abuse.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-report-abuse.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_reportAbuse","description":"Report a post f
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-toggle-like.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-toggle-like.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_toggleLike","description":"Toggle like stat
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-toggle-save.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-toggle-save.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_toggleSave","description":"Toggle save/book
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/posts-controller-view-tracking.api.mdx
+++ b/docs/user_related_apis_versioned/posts-controller-view-tracking.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"PostsController_viewTracking","description":"Record that a 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/publish-note.api.mdx
+++ b/docs/user_related_apis_versioned/publish-note.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Publish a note to QR.","parameters":[{"in"
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-accept-by-private-token.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-accept-by-private-token.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_acceptByPrivateToken","description":"Accept
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-accept-invite.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-accept-invite.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_acceptInvite","description":"Accept an invi
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-admins-access.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-admins-access.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_adminsAccess","description":"Grant or revok
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-create-new-group.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-create-new-group.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_createNewGroup","description":"Create a new
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-create-new-page.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-create-new-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_createNewPage","description":"Submit a requ
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-follow-page.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-follow-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_followPage","description":"Follow an organi
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-get-room-members.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-get-room-members.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomMembers","description":"Retrieve pag
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-get-room-posts.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-get-room-posts.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomPosts","description":"Retrieve pagin
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-get-room-profile-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-get-room-profile-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomProfileById","description":"Retrieve
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-get-room-profile.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-get-room-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRoomProfile","description":"Retrieve a r
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-get-rooms.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-get-rooms.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_getRooms","description":"Retrieve rooms the
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-invite-user-to-room.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-invite-user-to-room.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_inviteUserToRoom","description":"Send an in
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-join-room.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-join-room.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_joinRoom","description":"Join a public grou
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-leave-group.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-leave-group.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_leaveGroup","description":"Leave a group th
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-reject-invite.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-reject-invite.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_rejectInvite","description":"Decline an inv
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-remove-member.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-remove-member.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_removeMember","description":"Remove a user 
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-search-rooms.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-search-rooms.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_searchRooms","description":"Search for publ
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-unfollow-page.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-unfollow-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_unfollowPage","description":"Stop following
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-update-group.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-update-group.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_updateGroup","description":"Update group pr
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-update-page.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-update-page.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_updatePage","description":"Update page prop
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/rooms-controller-update-post-privacy.api.mdx
+++ b/docs/user_related_apis_versioned/rooms-controller-update-post-privacy.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"RoomsController_updatePostPrivacy","description":"Change th
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/scopes.mdx
+++ b/docs/user_related_apis_versioned/scopes.mdx
@@ -1,5 +1,6 @@
 ---
 id: scopes
+displayed_sidebar: APIsSidebar
 ---
 
 # OAuth2 Scopes

--- a/docs/user_related_apis_versioned/tags-controller-find.api.mdx
+++ b/docs/user_related_apis_versioned/tags-controller-find.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"TagsController_find","description":"Search for tags by quer
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/update-a-goal.api.mdx
+++ b/docs/user_related_apis_versioned/update-a-goal.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Update a goal","tags":["Goals"],"parameters":[{"in":"path",
 sidebar_class_name: "put api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/update-collection.api.mdx
+++ b/docs/user_related_apis_versioned/update-collection.api.mdx
@@ -9,7 +9,7 @@ api: {"description":"Update an existing collection.","tags":["Collections"],"par
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/update-note-by-id.api.mdx
+++ b/docs/user_related_apis_versioned/update-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Update a note by its ID.","parameters":[{"
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/user-related-apis.info.mdx
+++ b/docs/user_related_apis_versioned/user-related-apis.info.mdx
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 sidebar_position: 0
 hide_title: true
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiLogo from "@theme/ApiLogo";

--- a/docs/user_related_apis_versioned/users-controller-delete-account.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-delete-account.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_deleteAccount","description":"Permanently d
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-edit-profile.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-edit-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_editProfile","description":"Partially updat
 sidebar_class_name: "patch api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-follow-featured-users.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-follow-featured-users.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_followFeaturedUsers","description":"Follows
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-get-featured-users.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-get-featured-users.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getFeaturedUsers","description":"Returns a 
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-get-user-followers.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-get-user-followers.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getUserFollowers","description":"Retrieve a
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-get-user-following.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-get-user-following.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getUserFollowing","description":"Retrieve a
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-get-user-profile.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-get-user-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_getUserProfile","description":"Retrieve a u
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-profile.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_profile","description":"Retrieve the comple
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-remove-follower.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-remove-follower.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_removeFollower","description":"Remove a use
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-rooms.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-rooms.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_rooms","description":"Retrieve all rooms (g
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-search.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-search.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_search","description":"Search users by name
 sidebar_class_name: "get api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-toggle-follow.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-toggle-follow.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_toggleFollow","description":"Follow or unfo
 sidebar_class_name: "post api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docs/user_related_apis_versioned/users-controller-update-profile.api.mdx
+++ b/docs/user_related_apis_versioned/users-controller-update-profile.api.mdx
@@ -9,7 +9,7 @@ api: {"operationId":"UsersController_updateProfile","description":"Update user p
 sidebar_class_name: "put api-method"
 info_path: docs/user_related_apis_versioned/user-related-apis
 custom_edit_url: null
-displayed_sidebar: apiSidebar
+displayed_sidebar: APIsSidebar
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -194,9 +194,9 @@ const config = {
         items: [
           {
             type: "doc",
-            docId: "quickstart/index", // Points to your /docs/quickstart/index.md
+            docId: "tutorials/oidc/user-apis-quickstart",
             position: "left",
-            label: "Quick Start",
+            label: "User Quickstart",
           },
           {
             type: "doc",

--- a/scripts/set-api-displayed-sidebars.js
+++ b/scripts/set-api-displayed-sidebars.js
@@ -42,7 +42,7 @@ function getDisplayedSidebarId(filePath) {
     versionDirPattern.test(segment),
   );
 
-  return isVersionedDoc ? 'apiVersionedSidebar' : 'apiSidebar';
+  return isVersionedDoc ? 'APIsVersionedSidebar' : 'APIsSidebar';
 }
 
 function upsertDisplayedSidebar(content, displayedSidebarId) {

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,10 +13,6 @@ const contentAPIsVersions = require("./docs/content_apis_versioned/versions.json
 const userRelatedAPIsVersions = require("./docs/user_related_apis_versioned/versions.json");
 const oauth2APIsVersions = require("./docs/oauth2_apis_versioned/versions.json");
 const searchAPIsVersions = require("./docs/search_apis_versioned/versions.json");
-const {
-  versionSelector,
-  versionCrumb,
-} = require("docusaurus-plugin-openapi-docs/lib/sidebars/utils");
 
 const safeRequire = (relativePath, fallback) => {
   const fullPath = path.join(__dirname, relativePath);
@@ -28,19 +24,6 @@ const safeRequire = (relativePath, fallback) => {
 };
 
 const cloneSidebarItems = (items) => JSON.parse(JSON.stringify(items));
-
-const makeVersionSelectorItem = (versions) => ({
-  type: "html",
-  defaultStyle: true,
-  value: versionSelector(versions),
-  className: "version-button",
-});
-
-const makeVersionCrumbItem = (label) => ({
-  type: "html",
-  defaultStyle: true,
-  value: versionCrumb(label),
-});
 
 const makeReadingSessionsVsActivityDaysSidebarItem = (docId) => ({
   type: "category",
@@ -418,8 +401,6 @@ const versionedApiFamilies = [
 ];
 
 const makeApiFamilySidebar = (config) => [
-  makeVersionSelectorItem(config.versions),
-  makeVersionCrumbItem(config.versionLabel),
   {
     type: "category",
     label: config.label,
@@ -442,12 +423,134 @@ const makeSharedApiFamilyCategory = (config) => ({
   },
   collapsible: true,
   collapsed: true,
-  items: [
-    makeVersionSelectorItem(config.versions),
-    makeVersionCrumbItem(config.versionLabel),
-    ...stripIntroDoc(config.itemsBuilder(), config.introDocId),
-  ],
+  items: stripIntroDoc(config.itemsBuilder(), config.introDocId),
 });
+
+const buildSdkSidebarItems = () => [
+  {
+    type: "category",
+    label: "JS/TS",
+    link: {
+      type: "doc",
+      id: "sdk/javascript/index",
+    },
+    collapsible: true,
+    collapsed: false,
+    items: [
+      "sdk/javascript/chapters",
+      "sdk/javascript/verses",
+      "sdk/javascript/audio",
+      "sdk/javascript/resources",
+      "sdk/javascript/juzs",
+      "sdk/javascript/search",
+      "sdk/javascript/v1-migration-guide",
+    ],
+  },
+];
+
+const buildTutorialsSidebarItems = () => [
+  "tutorials/faq",
+  {
+    type: "category",
+    label: "Font & Page Rendering",
+    collapsible: true,
+    collapsed: false,
+    items: [
+      "tutorials/fonts/font-rendering",
+      "tutorials/fonts/page-layout",
+    ],
+  },
+  {
+    type: "category",
+    label: "OAuth2 / OpenID Connect",
+    collapsible: true,
+    collapsed: false,
+    items: [
+      "tutorials/oidc/getting-started-with-oauth2",
+      "tutorials/oidc/openid-connect",
+      "tutorials/oidc/example-integration",
+      "tutorials/oidc/client-setup",
+      {
+        type: "category",
+        label: "Mobile Apps",
+        link: {
+          type: "doc",
+          id: "tutorials/oidc/mobile-apps/index",
+        },
+        collapsible: true,
+        collapsed: false,
+        items: [
+          "tutorials/oidc/mobile-apps/react-native",
+          "tutorials/oidc/mobile-apps/android",
+          "tutorials/oidc/mobile-apps/iOS",
+        ],
+      },
+    ],
+  },
+];
+
+const makeSharedDocsSidebar = (apiFamilies) => [
+  {
+    type: "category",
+    label: "QF",
+    collapsible: false,
+    collapsed: false,
+    items: [
+      {
+        type: "doc",
+        id: "tutorials/oidc/user-apis-quickstart",
+        label: "User APIs Quickstart",
+      },
+      {
+        type: "doc",
+        id: "quickstart/index",
+        label: "Content APIs Quickstart",
+      },
+      {
+        type: "category",
+        label: "API",
+        collapsible: true,
+        collapsed: false,
+        items: [
+          ...apiFamilies.map(makeSharedApiFamilyCategory),
+          {
+            type: "doc",
+            id: "api/field-reference",
+            label: "Field Reference",
+          },
+          {
+            type: "doc",
+            id: "user_related_apis_versioned/scopes",
+            label: "OAuth2 Scopes",
+          },
+        ],
+      },
+      {
+        type: "category",
+        label: "SDKs",
+        link: {
+          type: "doc",
+          id: "sdk/index",
+        },
+        collapsible: true,
+        collapsed: false,
+        items: buildSdkSidebarItems(),
+      },
+      {
+        type: "doc",
+        id: "updates/index",
+        label: "Updates",
+      },
+      {
+        type: "category",
+        label: "Tutorials",
+        collapsible: true,
+        collapsed: false,
+        items: buildTutorialsSidebarItems(),
+      },
+    ],
+  },
+];
 
 // @ts-check
 
@@ -457,7 +560,7 @@ const sidebars = {
     {
       type: "doc",
       id: "quickstart/index",
-      label: "Quick Start Guide",
+      label: "Content APIs Quickstart",
     },
   ],
 
@@ -478,55 +581,11 @@ const sidebars = {
   ],
 
   tutorialsSidebar: [
-    "tutorials/faq",
-    {
-      type: "category",
-      label: "Font & Page Rendering",
-      items: [
-        "tutorials/fonts/font-rendering",
-        "tutorials/fonts/page-layout",
-      ],
-    },
-    {
-      type: "autogenerated",
-      dirName: "tutorials/oidc",
-    },
+    ...buildTutorialsSidebarItems(),
   ],
 
-  APIsSidebar: [
-    {
-      type: "doc",
-      id: "quickstart/index",
-      label: "Quick Start Guide",
-    },
-    {
-      type: "category",
-      label: "SDKs",
-      link: {
-        type: "doc",
-        id: "sdk/index",
-      },
-      items: [
-        {
-          type: "category",
-          label: "JS/TS",
-          link: {
-            type: "doc",
-            id: "sdk/javascript/index",
-          },
-          items: [
-            "sdk/javascript/chapters",
-            "sdk/javascript/verses",
-            "sdk/javascript/audio",
-            "sdk/javascript/resources",
-            "sdk/javascript/juzs",
-            "sdk/javascript/search",
-            "sdk/javascript/v1-migration-guide",
-          ],
-        },
-      ],
-    },
-  ],
+  APIsSidebar: makeSharedDocsSidebar(latestApiFamilies),
+  APIsVersionedSidebar: makeSharedDocsSidebar(versionedApiFamilies),
 
   "content-apis": makeApiFamilySidebar(contentApisLatestConfig),
   "content-apis-4.0.0": makeApiFamilySidebar(contentApisVersionedConfig),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import clsx from "clsx";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
@@ -12,7 +11,6 @@ import {
 import styles from "./index.module.css";
 
 function HomepageHeader() {
-  const { siteConfig } = useDocusaurusContext();
   const [activeModal, setActiveModal] = React.useState<
     "benefits" | "disclaimers" | null
   >(null);
@@ -53,13 +51,13 @@ function HomepageHeader() {
             className={clsx("button button--lg", styles.mobileRequestAccess)}
             to="/request-access"
           >
-            📨 Request Access
+            Request Access
           </Link>
           <Link
             className={clsx("button button--lg", styles.primaryButton)}
-            to="/docs/quickstart"
+            to="/docs/tutorials/oidc/user-apis-quickstart"
           >
-            🚀 Quick Start Guide
+            Start with User APIs
           </Link>
           <button
             type="button"
@@ -78,7 +76,7 @@ function HomepageHeader() {
         </div>
 
         <p className={clsx(styles.heroSubtitle, styles.heroLlmsCallout)}>
-          <strong>AI agents / LLMs</strong> — see{" "}
+          <strong>AI agents / LLMs</strong> - see{" "}
           <a href="/llms.txt">/llms.txt</a> for machine-readable OpenAPI
           specs.
         </p>


### PR DESCRIPTION
## Summary

Rework the docs navigation into a single versionless `QF` sidebar tree and promote the user quickstart over the content quickstart.

This keeps current/versioned docs internally separate where needed, but removes visible version clutter from the navigation until multiple real versions need to be surfaced again.

## What Changed

- built shared `APIsSidebar` and `APIsVersionedSidebar` trees under a single `QF` root
- removed visible version selectors, version crumbs, and version labels from sidebar navigation
- promoted the user quickstart to the top of the shared nav and removed its duplicate appearance under Tutorials
- renamed the quickstart pages to:
  - `User Related APIs Quickstart Guide`
  - `Content APIs Quickstart Guide`
- shortened UI-facing labels after review:
  - sidebar labels to `User APIs Quickstart` and `Content APIs Quickstart`
  - navbar label to `User Quickstart`
  - homepage CTA to `Start with User APIs`
- updated the homepage CTA and navbar quickstart target to the user quickstart
- added explicit shared-sidebar bindings for the relevant manual docs
- changed generated API docs to use `APIsSidebar` and `APIsVersionedSidebar`
- added a small `Mobile Apps` landing doc so the tutorial route remains valid under the explicit tutorial tree
- regenerated generated API docs and normalized their displayed sidebar assignments

## Why

The docs currently over-emphasized the content quickstart, even though the user-related APIs are the area that needs promotion.

At the same time, the sidebar was fragmented and exposed version details that are not useful yet because each API family currently has only one version. This PR simplifies that experience into one coherent navigation tree and makes the user quickstart the primary entry point.

## Impact

- readers now see one consistent sidebar structure across current docs and versioned API docs
- version numbers are hidden from navigation without changing existing routes
- the user quickstart is the main promoted flow from the homepage, navbar, and top of the sidebar
- quickstart page titles stay explicit, while sidebar/navbar/button labels are shortened to avoid overly long UI text

## Validation

- `yarn gen-all`
- `npx docusaurus build`

The final direct Docusaurus build completed successfully after the sidebar and label changes.

## Notes

This PR includes the generated API doc updates because the displayed sidebar IDs are stamped into the generated files and need to stay in sync with the new shared sidebar structure.