### PR TITLE
[codex] clarify frontend PKCE with server-side token exchange

### DIFF
--- a/docs/tutorials/oidc/getting-started-with-oauth2.mdx
+++ b/docs/tutorials/oidc/getting-started-with-oauth2.mdx
@@ -186,25 +186,32 @@ Here's how the OAuth2 Authorization Code flow works when user consent is needed 
 sequenceDiagram
     actor User
     participant App as Your App
+    participant Backend as Your Backend
     participant Auth as Quran.Foundation<br/>Authorization Server
     participant API as Quran.Foundation<br/>Resources Server
 
     User->>App: Click "Login"
-    App->>Auth: Request Token
+    App->>Auth: Start login with PKCE
     Auth->>User: Login and consent
     User->>Auth: Approve
     Auth-->>App: Authorization Code
-    App->>Auth: Exchange code for token
-    Auth-->>App: Token Response<br/>(access_token, refresh_token)
+    App->>Backend: Send code + PKCE verifier
+    Backend->>Auth: Exchange code for token
+    Auth-->>Backend: Token Response<br/>(access_token, refresh_token)
+    Backend-->>App: Session or token payload
 
     App->>API: Use token to call Quran.Foundation's API
     API-->>App: Requested resource
 
-    Note over App,Auth: Access token expires (1 hour)
+    Note over App,Backend: Access token expires (1 hour)
 
-    App->>Auth: Re-request access_token using refresh_token
-    Auth-->>App: New access_token and refresh_token
+    App->>Backend: Request refreshed token
+    Backend->>Auth: Refresh using refresh_token
+    Auth-->>Backend: New access_token and refresh_token
+    Backend-->>App: Updated session or token payload
 ```
+
+> If Quran Foundation explicitly provisions your client as public with `token_endpoint_auth_method=none`, the app can exchange the code directly. For the current Request Access flow, use the backend exchange pattern shown above.
 
 > 🔧 **Ready to code?** Check out the [User Related APIs Quickstart Guide](/docs/tutorials/oidc/user-apis-quickstart) for copy-paste examples, or see the [Web Integration Example](/docs/tutorials/oidc/example-integration) and the [hosted demo](https://oauth2-client-prelive.quran.foundation/).
 

--- a/docs/tutorials/oidc/mobile-apps/_obtain_client_credentials.mdx
+++ b/docs/tutorials/oidc/mobile-apps/_obtain_client_credentials.mdx
@@ -1,6 +1,6 @@
 ## Obtaining OAuth 2.0 client credentials
 
-> A perquisite to creating client credentials is for your app to have the value of the redirect URL where the user will land after successfully authenticating/logging out implemented.
+> A prerequisite to creating client credentials is for your app to have the value of the redirect URL where the user will land after successfully authenticating/logging out implemented.
 
 Once you have the redirect URL, please submit your OAuth2 [Application](/request-access).
 

--- a/docs/tutorials/oidc/mobile-apps/react-native.mdx
+++ b/docs/tutorials/oidc/mobile-apps/react-native.mdx
@@ -39,10 +39,13 @@ WebBrowser.maybeCompleteAuthSession();
 const CLIENT_ID = "YOUR_CLIENT_ID"; // From your OAuth application
 const REDIRECT_URI = "exp://192.168.x.x:8081"; // Your Expo dev URL or custom scheme
 const BACKEND_BASE_URL = "https://your-backend.example.com";
+const USE_PRELIVE = true; // set to false for production
 
-// OAuth2 authorization endpoint (use prelive for testing)
+// OAuth2 authorization endpoint
 const discovery = {
-  authorizationEndpoint: "https://oauth2.quran.foundation/oauth2/auth",
+  authorizationEndpoint: USE_PRELIVE
+    ? "https://prelive-oauth2.quran.foundation/oauth2/auth"
+    : "https://oauth2.quran.foundation/oauth2/auth",
 };
 
 export default function App() {
@@ -195,7 +198,7 @@ const fetchBookmarks = async () => {
     "https://apis.quran.foundation/auth/v1/bookmarks",
     {
       headers: {
-        "x-auth-token": authTokens.accessToken,
+        "x-auth-token": authSession.accessToken,
         "x-client-id": CLIENT_ID,
       },
     }
@@ -229,7 +232,7 @@ If your app keeps refresh tokens locally, use `expo-secure-store` to persist the
 
 ```javascript
 import * as SecureStore from "expo-secure-store";
-await SecureStore.setItemAsync("refreshToken", authTokens.refreshToken);
+await SecureStore.setItemAsync("refreshToken", authSession.refreshToken);
 ```
 
 :::

--- a/docs/tutorials/oidc/user-apis-quickstart.mdx
+++ b/docs/tutorials/oidc/user-apis-quickstart.mdx
@@ -58,10 +58,13 @@ WebBrowser.maybeCompleteAuthSession();
 const CLIENT_ID = "YOUR_CLIENT_ID";
 const REDIRECT_URI = "yourapp://callback";
 const BACKEND_BASE_URL = "https://your-backend.example.com";
+const USE_PRELIVE = true; // set to false for production
 
-// OAuth2 authorization endpoint - use prelive for testing, production for live apps
+// OAuth2 authorization endpoint
 const discovery = {
-  authorizationEndpoint: "https://oauth2.quran.foundation/oauth2/auth",
+  authorizationEndpoint: USE_PRELIVE
+    ? "https://prelive-oauth2.quran.foundation/oauth2/auth"
+    : "https://oauth2.quran.foundation/oauth2/auth",
 };
 
 export default function App() {
@@ -218,12 +221,63 @@ const authBaseUrl =
 app.post("/api/auth/qf/exchange", async (req, res) => {
   const { code, codeVerifier, redirectUri } = req.body;
 
+  if (!code || !codeVerifier || !redirectUri) {
+    return res.status(400).json({
+      error:
+        "Missing required fields: code, codeVerifier, and redirectUri are required",
+    });
+  }
+
   try {
     const params = new URLSearchParams();
     params.append("grant_type", "authorization_code");
     params.append("code", code);
     params.append("redirect_uri", redirectUri);
     params.append("code_verifier", codeVerifier);
+
+    const tokenResponse = await axios.post(
+      `${authBaseUrl}/oauth2/token`,
+      params.toString(),
+      {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        auth: {
+          username: process.env.CLIENT_ID,
+          password: process.env.CLIENT_SECRET,
+        },
+      }
+    );
+
+    const token = tokenResponse.data;
+    // jwt.decode does not verify the ID token signature or claims.
+    // In production, validate id_token with OIDC/JWKS as shown in:
+    // /docs/tutorials/oidc/getting-started-with-oauth2#validate-id-tokens-with-jwks
+    const user = token.id_token ? jwt.decode(token.id_token) : null;
+
+    res.json({
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token,
+      idToken: token.id_token,
+      expiresIn: token.expires_in,
+      user,
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to exchange authorization code" });
+  }
+});
+
+app.post("/api/auth/qf/refresh", async (req, res) => {
+  const { refreshToken } = req.body;
+
+  if (!refreshToken) {
+    return res
+      .status(400)
+      .json({ error: "Missing required field: refreshToken" });
+  }
+
+  try {
+    const params = new URLSearchParams();
+    params.append("grant_type", "refresh_token");
+    params.append("refresh_token", refreshToken);
 
     const tokenResponse = await axios.post(
       `${authBaseUrl}/oauth2/token`,
@@ -247,32 +301,6 @@ app.post("/api/auth/qf/exchange", async (req, res) => {
       expiresIn: token.expires_in,
       user,
     });
-  } catch (error) {
-    res.status(500).json({ error: "Failed to exchange authorization code" });
-  }
-});
-
-app.post("/api/auth/qf/refresh", async (req, res) => {
-  const { refreshToken } = req.body;
-
-  try {
-    const params = new URLSearchParams();
-    params.append("grant_type", "refresh_token");
-    params.append("refresh_token", refreshToken);
-
-    const tokenResponse = await axios.post(
-      `${authBaseUrl}/oauth2/token`,
-      params.toString(),
-      {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        auth: {
-          username: process.env.CLIENT_ID,
-          password: process.env.CLIENT_SECRET,
-        },
-      }
-    );
-
-    res.json(tokenResponse.data);
   } catch (error) {
     res.status(500).json({ error: "Failed to refresh access token" });
   }


### PR DESCRIPTION
## Summary
- clarify the recommended OAuth integration shape for current Request Access clients
- keep frontend and mobile login + PKCE examples in the docs
- recommend server-side authorization-code exchange and refresh for currently issued clients
- keep direct in-app token exchange documented only for clients explicitly registered with `token_endpoint_auth_method=none`

## Why
The docs could be read as if direct in-app token exchange was the default path for every client. In practice, the current Request Access flow provisions confidential clients, so the recommended integration shape is: app handles login + PKCE, backend handles code exchange and refresh.

## Validation
- `git diff --check`
- Did not rerun `yarn build` or `yarn typecheck`; earlier `yarn typecheck` failure in `src/theme/ApiDemoPanel/Curl/index.tsx` is still unrelated to these docs changes