### PR TITLE
[codex] fix OIDC ID token claims table

### DIFF
--- a/docs/tutorials/oidc/getting-started-with-oauth2.mdx
+++ b/docs/tutorials/oidc/getting-started-with-oauth2.mdx
@@ -202,7 +202,7 @@ cursor.execute("""
 | `sub`          | Unique user ID (stable, never changes)  | **Primary key** for linking to your DB |
 | `email`        | User's email (if `email` scope granted) | Display, notifications                 |
 | `first_name`   | User's first name                       | Personalization                        |
-| `name`         | Full name                               | Display                                |
+| `last_name`    | User's last name                        | Personalization, display               |
 
 :::warning Don't use email as primary key
 Always use `sub` as the foreign key to link users. Email addresses can change, but `sub` is permanent and unique.


### PR DESCRIPTION
## What changed
Updated the OIDC getting-started tutorial to replace the incorrect `name` ID token claim entry with `last_name`.

## Why
The current auth implementation documents and emits `first_name` and `last_name` in the OIDC token shape. The tutorial table had drifted and listed `name`, which does not match the current backend behavior.

## Impact
This keeps the integration guide aligned with the actual claim shape and avoids misleading integrators about which profile fields are available in the ID token.

## Validation
- Reviewed the OIDC tutorial example and UserInfo docs
- Verified the auth backend claim mapping in the consent flow
