### PR TITLE
[codex] Add OAuth scopes to docs

### DIFF
--- a/docs/tutorials/oidc/user-apis-quickstart.mdx
+++ b/docs/tutorials/oidc/user-apis-quickstart.mdx
@@ -95,9 +95,8 @@ Request only the scopes your app actually needs.
 
 | Scope | Access |
 | --- | --- |
-| `openid` | OpenID Connect authentication |
-| `profile` | Basic profile information |
-| `offline_access` | Allows obtaining refresh tokens |
+| `openid` | OpenID Connect identity claims in the `id_token` |
+| `offline_access` | Refresh tokens for long-lived sessions |
 | `user` | User profile information |
 | `bookmark` | Bookmarked verses |
 | `collection` | Saved collections |

--- a/docs/tutorials/oidc/user-apis-quickstart.mdx
+++ b/docs/tutorials/oidc/user-apis-quickstart.mdx
@@ -95,8 +95,9 @@ Request only the scopes your app actually needs.
 
 | Scope | Access |
 | --- | --- |
-| `openid` | OpenID Connect identity claims in the `id_token` |
-| `offline_access` | Refresh tokens for long-lived sessions |
+| `openid` | OpenID Connect authentication |
+| `profile` | Basic profile information |
+| `offline_access` | Allows obtaining refresh tokens |
 | `user` | User profile information |
 | `bookmark` | Bookmarked verses |
 | `collection` | Saved collections |

--- a/docs/user_related_apis_versioned/scopes.mdx
+++ b/docs/user_related_apis_versioned/scopes.mdx
@@ -15,7 +15,6 @@ granting access to the scopes your app is requesting first.
 | Scope          | Description                    |
 | -------------- | ------------------------------ |
 | openid         | OpenID Connect authentication  |
-| profile        | Basic profile information      |
 | offline_access | Allows obtaining refresh tokens |
 
 ## Content

--- a/docs/user_related_apis_versioned/scopes.mdx
+++ b/docs/user_related_apis_versioned/scopes.mdx
@@ -10,6 +10,14 @@ an access token. When requesting an accessing token, clients should also request
 interested in getting access to. If the APIs are user-related, the user will need to consent to
 granting access to the scopes your app is requesting first.
 
+## Standard OAuth2
+
+| Scope          | Description                    |
+| -------------- | ------------------------------ |
+| openid         | OpenID Connect authentication  |
+| profile        | Basic profile information      |
+| offline_access | Allows obtaining refresh tokens |
+
 ## Content
 
 | Scope   | Description                                                                      |


### PR DESCRIPTION
## Summary
- add the standard OAuth scopes `openid` and `offline_access` to the main scopes reference page
- keep the PR scoped to `docs/user_related_apis_versioned/scopes.mdx` only

## Why
The scopes reference should include the standard OAuth scopes developers request alongside API scopes, without changing the quickstart page in this PR.

## Validation
- `git diff --check`
