### PR TITLE
[codex] publish robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /search
+Disallow: /request-scopes
+
+Sitemap: https://api-docs.quran.foundation/sitemap.xml


### PR DESCRIPTION
## What changed
- add `static/robots.txt` so the site publishes `/robots.txt` from the site root
- define explicit crawl rules with a global `User-agent` group
- block low-value or private routes from crawling: `/search` and `/request-scopes`
- advertise the public sitemap at `https://api-docs.quran.foundation/sitemap.xml`

## Why
The site did not publish `/robots.txt`, so discoverability checks failed and crawlers had no explicit crawl policy for the docs site.

## Impact
- `/robots.txt` will exist at the site root after deploy
- crawlers get a clear allow/disallow policy
- the docs sitemap becomes discoverable from the robots file

## Root cause
The site root was missing a `robots.txt` asset.

## Validation
- served `static/robots.txt` locally and verified `GET /robots.txt` returns `200`
- verified the response `Content-Type` is `text/plain`