### PR TITLE
[codex] add discovery headers

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -15,7 +15,20 @@
 
 # Homepage discovery links for agents and API consumers
 /
-  Link: </llms.txt>; rel="describedby"; type="text/plain", </openAPI/content/v4.json>; rel="service-desc"; type="application/json", </openAPI/oauth2-apis/v1.json>; rel="service-desc"; type="application/json", </openAPI/search/v1.json>; rel="service-desc"; type="application/json", </openAPI/user-related-apis/v1.json>; rel="service-desc"; type="application/json", </docs/content_apis_versioned/content-apis/>; rel="service-doc"; type="text/html", </docs/oauth2_apis_versioned/oauth-2-apis/>; rel="service-doc"; type="text/html", </docs/search_apis_versioned/quran-foundation-search-api/>; rel="service-doc"; type="text/html", </docs/user_related_apis_versioned/user-related-apis/>; rel="service-doc"; type="text/html", </docs/tutorials/oidc/getting-started-with-oauth2/>; rel="service-doc"; type="text/html", </docs/quickstart/>; rel="service-doc"; type="text/html", </docs/tutorials/oidc/user-apis-quickstart/>; rel="service-doc"; type="text/html", </docs/user_related_apis_versioned/scopes/>; rel="service-doc"; type="text/html", </request-access/>; rel="service-doc"; type="text/html"
+  Link: </llms.txt>; rel="describedby"; type="text/plain"
+  Link: </openAPI/content/v4.json>; rel="service-desc"; type="application/json"
+  Link: </openAPI/oauth2-apis/v1.json>; rel="service-desc"; type="application/json"
+  Link: </openAPI/search/v1.json>; rel="service-desc"; type="application/json"
+  Link: </openAPI/user-related-apis/v1.json>; rel="service-desc"; type="application/json"
+  Link: </docs/content_apis_versioned/content-apis/>; rel="service-doc"; type="text/html"
+  Link: </docs/oauth2_apis_versioned/oauth-2-apis/>; rel="service-doc"; type="text/html"
+  Link: </docs/search_apis_versioned/quran-foundation-search-api/>; rel="service-doc"; type="text/html"
+  Link: </docs/user_related_apis_versioned/user-related-apis/>; rel="service-doc"; type="text/html"
+  Link: </docs/tutorials/oidc/getting-started-with-oauth2/>; rel="service-doc"; type="text/html"
+  Link: </docs/quickstart/>; rel="service-doc"; type="text/html"
+  Link: </docs/tutorials/oidc/user-apis-quickstart/>; rel="service-doc"; type="text/html"
+  Link: </docs/user_related_apis_versioned/scopes/>; rel="service-doc"; type="text/html"
+  Link: </request-access/>; rel="service-doc"; type="text/html"
 
 # Cache hashed JavaScript and CSS files for 1 year (they have content hash in filename)
 /assets/js/*.js

--- a/static/_headers
+++ b/static/_headers
@@ -13,6 +13,10 @@
   # Cache-Control for HTML pages: no long-term cache
   Cache-Control: public, max-age=0, must-revalidate
 
+# Homepage discovery links for agents and API consumers
+/
+  Link: </llms.txt>; rel="describedby"; type="text/plain", </openAPI/content/v4.json>; rel="service-desc"; type="application/json", </openAPI/oauth2-apis/v1.json>; rel="service-desc"; type="application/json", </openAPI/search/v1.json>; rel="service-desc"; type="application/json", </openAPI/user-related-apis/v1.json>; rel="service-desc"; type="application/json", </docs/content_apis_versioned/content-apis/>; rel="service-doc"; type="text/html", </docs/oauth2_apis_versioned/oauth-2-apis/>; rel="service-doc"; type="text/html", </docs/search_apis_versioned/quran-foundation-search-api/>; rel="service-doc"; type="text/html", </docs/user_related_apis_versioned/user-related-apis/>; rel="service-doc"; type="text/html", </docs/tutorials/oidc/getting-started-with-oauth2/>; rel="service-doc"; type="text/html", </docs/quickstart/>; rel="service-doc"; type="text/html", </docs/tutorials/oidc/user-apis-quickstart/>; rel="service-doc"; type="text/html", </docs/user_related_apis_versioned/scopes/>; rel="service-doc"; type="text/html", </request-access/>; rel="service-doc"; type="text/html"
+
 # Cache hashed JavaScript and CSS files for 1 year (they have content hash in filename)
 /assets/js/*.js
   Cache-Control: public, max-age=31536000, immutable
@@ -39,6 +43,10 @@
 
 # Sitemap and OpenSearch: cache for 1 day
 /sitemap.xml
+  Cache-Control: public, max-age=86400
+
+/robots.txt
+  ! Cache-Control
   Cache-Control: public, max-age=86400
 
 /opensearch.xml


### PR DESCRIPTION
## What changed
- add homepage `Link` discovery headers for machine-readable API descriptions and human-facing documentation entry points
- add a scoped `/robots.txt` header rule in `static/_headers` so the robots asset gets its intended cache policy without inheriting the default HTML cache header
- keep the change scoped to `static/_headers` only

## Why
The homepage did not advertise useful discovery relations for agents and API consumers. In addition, the existing `robots.txt` asset on `main` should be handled through headers only, not re-added in this branch.

## Impact
- `GET /` will return additional `Link` relations: `describedby`, `service-desc`, and `service-doc`
- `GET /robots.txt` will keep using the existing file from `main`, with the intended cache behavior from `_headers`
- agents and tooling have a clearer machine-readable and human-readable discovery path from the homepage

## Root cause
The Cloudflare Pages header configuration did not include discovery `Link` relations on the homepage, and the robots asset needed a path-specific header override rather than a duplicate file addition.

## Validation
- verified the homepage discovery header payload is 1079 characters, below the Cloudflare Pages 2000-character per-header limit
- ran local Cloudflare Pages dev and confirmed `GET /` returns the planned discovery `Link` header
- ran local Cloudflare Pages dev and confirmed `GET /robots.txt` returns `200`, `Content-Type: text/plain; charset=utf-8`, and `Cache-Control: public, max-age=86400`
- verified all linked production targets currently return `200`