### PR TITLE
[codex] add web bot auth and AI crawler policies

### DIFF
--- a/static/.well-known/http-message-signatures-directory
+++ b/static/.well-known/http-message-signatures-directory
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "d51ioAvkOA8NjN6gyQSruQYw1nk8anfXgsafEjeNRMk",
+      "use": "sig",
+      "alg": "EdDSA",
+      "kid": "L1pps7747GfGbs2W6EMd3jOZrNIsPcZjSq5qZPTtzaM"
+    }
+  ]
+}

--- a/static/_headers
+++ b/static/_headers
@@ -62,6 +62,10 @@
   ! Cache-Control
   Cache-Control: public, max-age=86400
 
+/.well-known/http-message-signatures-directory
+  Content-Type: application/http-message-signatures-directory+json
+  Cache-Control: public, max-age=86400
+
 /opensearch.xml
   Cache-Control: public, max-age=86400
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,55 @@
+# Allow search and user-directed AI retrieval for the public docs, but opt out of AI training.
+User-agent: OAI-SearchBot
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Disallow: /search
+Disallow: /request-scopes
+
+User-agent: Claude-Web
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Disallow: /search
+Disallow: /request-scopes
+
+User-agent: ClaudeBot
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Disallow: /search
+Disallow: /request-scopes
+
+User-agent: Amazonbot
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Disallow: /search
+Disallow: /request-scopes
+
+# Block training and extended-use crawlers from fetching site content.
+User-agent: GPTBot
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Disallow: /
+
+User-agent: Google-Extended
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Disallow: /
+
+User-agent: anthropic-ai
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Disallow: /
+
+User-agent: Bytespider
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Disallow: /
+
+User-agent: CCBot
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Disallow: /
+
+User-agent: Applebot-Extended
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Disallow: /
+
 User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Disallow: /search
 Disallow: /request-scopes

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,25 +1,34 @@
-# Allow search and user-directed AI retrieval for the public docs, but opt out of AI training.
+# Allow documented search/indexing bots, but opt out of training and live AI input.
 User-agent: OAI-SearchBot
-User-agent: Claude-Web
-User-agent: ClaudeBot
-User-agent: Amazonbot
-Content-Signal: ai-train=no, search=yes, ai-input=yes
+User-agent: Claude-SearchBot
+User-agent: Amzn-SearchBot
+User-agent: Applebot
+Content-Signal: ai-train=no, search=yes, ai-input=no
 Allow: /
 Disallow: /search
 Disallow: /request-scopes
 
-# Block training and extended-use crawlers from fetching site content.
+# Block documented training, grounding, and user-fetch bots.
 User-agent: GPTBot
+User-agent: ClaudeBot
+User-agent: Claude-User
+User-agent: Amazonbot
+User-agent: Amzn-User
 User-agent: Google-Extended
-User-agent: anthropic-ai
-User-agent: Bytespider
-User-agent: CCBot
 User-agent: Applebot-Extended
 Content-Signal: ai-train=no, search=no, ai-input=no
 Disallow: /
 
+# Block legacy or compatibility AI crawler tokens explicitly.
+User-agent: Claude-Web
+User-agent: anthropic-ai
+User-agent: Bytespider
+User-agent: CCBot
+Content-Signal: ai-train=no, search=no, ai-input=no
+Disallow: /
+
 User-agent: *
-Content-Signal: ai-train=no, search=yes, ai-input=yes
+Content-Signal: ai-train=no, search=yes, ai-input=no
 Allow: /
 Disallow: /search
 Disallow: /request-scopes

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,34 +1,38 @@
-# Allow documented search/indexing bots, but opt out of training and live AI input.
+# Allow documented search and user-fetch bots for major AI assistants.
 User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
 User-agent: Claude-SearchBot
+User-agent: Claude-User
 User-agent: Amzn-SearchBot
+User-agent: Amzn-User
+User-agent: PerplexityBot
+User-agent: Perplexity-User
 User-agent: Applebot
-Content-Signal: ai-train=no, search=yes, ai-input=no
+User-agent: MistralAI-User
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Disallow: /search
 Disallow: /request-scopes
 
-# Block documented training, grounding, and user-fetch bots.
+# Allow Gemini grounding/search while signaling a no-training preference.
+User-agent: Google-Extended
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+Allow: /
+Disallow: /search
+Disallow: /request-scopes
+
+# Block documented training-only bots.
 User-agent: GPTBot
 User-agent: ClaudeBot
-User-agent: Claude-User
 User-agent: Amazonbot
-User-agent: Amzn-User
-User-agent: Google-Extended
 User-agent: Applebot-Extended
 Content-Signal: ai-train=no, search=no, ai-input=no
 Disallow: /
 
-# Block legacy or compatibility AI crawler tokens explicitly.
-User-agent: Claude-Web
-User-agent: anthropic-ai
-User-agent: Bytespider
-User-agent: CCBot
-Content-Signal: ai-train=no, search=no, ai-input=no
-Disallow: /
-
+# Default to public search and live retrieval for other compliant agents,
+# including providers that have not published stable robots.txt bot tokens yet.
 User-agent: *
-Content-Signal: ai-train=no, search=yes, ai-input=no
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Disallow: /search
 Disallow: /request-scopes

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,22 +1,7 @@
 # Allow search and user-directed AI retrieval for the public docs, but opt out of AI training.
 User-agent: OAI-SearchBot
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Allow: /
-Disallow: /search
-Disallow: /request-scopes
-
 User-agent: Claude-Web
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Allow: /
-Disallow: /search
-Disallow: /request-scopes
-
 User-agent: ClaudeBot
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Allow: /
-Disallow: /search
-Disallow: /request-scopes
-
 User-agent: Amazonbot
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
@@ -25,27 +10,12 @@ Disallow: /request-scopes
 
 # Block training and extended-use crawlers from fetching site content.
 User-agent: GPTBot
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Disallow: /
-
 User-agent: Google-Extended
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Disallow: /
-
 User-agent: anthropic-ai
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Disallow: /
-
 User-agent: Bytespider
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Disallow: /
-
 User-agent: CCBot
-Content-Signal: ai-train=no, search=yes, ai-input=yes
-Disallow: /
-
 User-agent: Applebot-Extended
-Content-Signal: ai-train=no, search=yes, ai-input=yes
+Content-Signal: ai-train=no, search=no, ai-input=no
 Disallow: /
 
 User-agent: *


### PR DESCRIPTION
## What changed
- added a JWKS at `/.well-known/http-message-signatures-directory` so the site can publish a Web Bot Auth verification directory
- added a Cloudflare Pages header rule to serve that endpoint as `application/http-message-signatures-directory+json`
- expanded `robots.txt` with explicit AI crawler rules and `Content-Signal` directives for training, search, and AI input preferences

## Why
The site was missing the bot identity and crawler policy signals expected by agent-readiness checks:
- no public Web Bot Auth directory
- no explicit AI crawler blocks for bots such as `GPTBot`, `OAI-SearchBot`, `Claude-Web`, and `Google-Extended`
- no `Content-Signal` declarations in `robots.txt`

## Impact
- receiving sites can discover the site's Web Bot Auth public key directory
- AI crawlers now receive explicit per-agent crawl instructions instead of only the wildcard policy
- training is opted out while search and live AI input remain allowed by declared policy

## Validation
- ran `git diff --cached --check`
- parsed and validated the JWKS shape with Node
- did not run a full Docusaurus production build here because this repo's build path regenerates large API docs and exceeded the CLI timeout during verification
