### PR TITLE
[codex] enable markdown negotiation for agents

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,14 @@
+import runtime from "../src/markdown-negotiation-runtime.cjs";
+
+const { negotiateMarkdownResponse } = runtime;
+
+export async function onRequest(context) {
+  const { env, next, request } = context;
+  const response = await next();
+
+  return negotiateMarkdownResponse({
+    assetsFetch: env.ASSETS.fetch.bind(env.ASSETS),
+    request,
+    response,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.1",
     "@tsconfig/docusaurus": "^1.0.5",
+    "domutils": "^3.0.1",
+    "htmlparser2": "^8.0.1",
     "typescript": "^4.7.4",
     "wrangler": "^4.42.0"
   },

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -12,6 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { exportMarkdownFiles } = require('../src/build-markdown.cjs');
 
 const BASE_URL = 'https://api-docs.quran.foundation';
 
@@ -237,6 +238,14 @@ function llmsTxtPlugin(context) {
       fs.writeFileSync(outFile, content, 'utf8');
       console.log(
         `[llms-txt-plugin] Generated ${outFile} with ${linkCount} links`,
+      );
+
+      // 3. Emit markdown siblings for every generated HTML page so Cloudflare
+      //    Pages middleware can negotiate `Accept: text/markdown` without
+      //    changing the default HTML experience for browsers.
+      const exportedCount = exportMarkdownFiles(outDir);
+      console.log(
+        `[llms-txt-plugin] Generated ${exportedCount} markdown page variants`,
       );
     },
   };

--- a/src/build-markdown.cjs
+++ b/src/build-markdown.cjs
@@ -286,7 +286,7 @@ function renderInlineCode(node) {
     return "";
   }
 
-  const fence = code.includes("`") ? "``" : "`";
+  const fence = createInlineCodeFence(code);
   return `${fence}${code}${fence}`;
 }
 
@@ -315,6 +315,16 @@ function createCodeFence(code) {
   );
 
   return "`".repeat(Math.max(3, longestRun + 1));
+}
+
+function createInlineCodeFence(code) {
+  const backtickRuns = code.match(/`+/g) || [];
+  const longestRun = backtickRuns.reduce(
+    (maxLength, run) => Math.max(maxLength, run.length),
+    0,
+  );
+
+  return "`".repeat(Math.max(1, longestRun + 1));
 }
 
 function renderList(node, ordered, context) {

--- a/src/build-markdown.cjs
+++ b/src/build-markdown.cjs
@@ -302,8 +302,19 @@ function renderCodeBlock(node, context) {
     return "";
   }
 
+  const fence = createCodeFence(code);
   const languageSuffix = language || "";
-  return `\`\`\`${languageSuffix}\n${code}\n\`\`\`\n\n`;
+  return `${fence}${languageSuffix}\n${code}\n${fence}\n\n`;
+}
+
+function createCodeFence(code) {
+  const backtickRuns = code.match(/`+/g) || [];
+  const longestRun = backtickRuns.reduce(
+    (maxLength, run) => Math.max(maxLength, run.length),
+    0,
+  );
+
+  return "`".repeat(Math.max(3, longestRun + 1));
 }
 
 function renderList(node, ordered, context) {

--- a/src/build-markdown.cjs
+++ b/src/build-markdown.cjs
@@ -1,0 +1,559 @@
+const fs = require("fs");
+const path = require("path");
+const { parseDocument } = require("htmlparser2");
+const {
+  findOne,
+  getAttributeValue,
+  getChildren,
+  isTag,
+  isText,
+} = require("domutils");
+
+const BASE_URL = "https://api-docs.quran.foundation";
+
+const SKIPPED_TAGS = new Set([
+  "aside",
+  "button",
+  "form",
+  "input",
+  "label",
+  "nav",
+  "noscript",
+  "option",
+  "script",
+  "select",
+  "style",
+  "svg",
+  "textarea",
+]);
+
+const SKIPPED_CLASS_PATTERNS = [
+  /breadcrumbs/i,
+  /buttonGroup/i,
+  /copyButton/i,
+  /DocSearch/i,
+  /hash-link/i,
+  /navbar/i,
+  /pagination-nav/i,
+  /tableOfContents/i,
+  /theme-back-to-top-button/i,
+  /tocCollapsible/i,
+];
+
+function buildMarkdownDocument({ html, sourceUrl }) {
+  const document = parseDocument(html, { decodeEntities: true });
+  const title = readTitle(document);
+  const description = readMetaContent(document, "description");
+  const root = findContentRoot(document);
+  const content = cleanupMarkdown(
+    renderNodes(getChildren(root) || [], {
+      listDepth: 0,
+      sourceUrl,
+    }),
+  );
+
+  if (!content) {
+    return "";
+  }
+
+  const frontMatterLines = ["---"];
+
+  if (title) {
+    frontMatterLines.push(`title: ${quoteYaml(title)}`);
+  }
+
+  if (sourceUrl) {
+    frontMatterLines.push(`source: ${quoteYaml(sourceUrl)}`);
+  }
+
+  if (description) {
+    frontMatterLines.push(`description: ${quoteYaml(description)}`);
+  }
+
+  frontMatterLines.push("---", "");
+
+  return `${frontMatterLines.join("\n")}${content}\n`;
+}
+
+function exportMarkdownFiles(outDir) {
+  const htmlFiles = walkHtmlFiles(outDir);
+  let exportedCount = 0;
+
+  for (const filePath of htmlFiles) {
+    const relativeHtmlPath = path.relative(outDir, filePath);
+    const markdown = buildMarkdownDocument({
+      html: fs.readFileSync(filePath, "utf8"),
+      sourceUrl: toPublicUrl(relativeHtmlPath),
+    });
+
+    if (!markdown) {
+      continue;
+    }
+
+    const markdownFilePath = filePath.replace(/\.html$/i, ".md");
+    fs.writeFileSync(markdownFilePath, markdown, "utf8");
+    exportedCount += 1;
+  }
+
+  return exportedCount;
+}
+
+function walkHtmlFiles(dir) {
+  const files = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...walkHtmlFiles(entryPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.toLowerCase().endsWith(".html")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function toPublicUrl(relativeHtmlPath) {
+  const normalizedPath = relativeHtmlPath.split(path.sep).join("/");
+
+  if (normalizedPath === "index.html") {
+    return `${BASE_URL}/`;
+  }
+
+  if (normalizedPath.endsWith("/index.html")) {
+    return `${BASE_URL}/${normalizedPath.slice(0, -"index.html".length)}`;
+  }
+
+  return `${BASE_URL}/${normalizedPath}`;
+}
+
+function findContentRoot(document) {
+  return (
+    findFirstTag(document, "article") ||
+    findFirstTag(document, "main") ||
+    findFirstTag(document, "body") ||
+    document
+  );
+}
+
+function findFirstTag(document, tagName) {
+  return findOne(
+    (node) => isTag(node) && node.name === tagName,
+    getChildren(document) || [],
+    true,
+  );
+}
+
+function readTitle(document) {
+  const titleNode = findFirstTag(document, "title");
+  if (!titleNode) {
+    return "";
+  }
+
+  return cleanupInline(renderNodes(getChildren(titleNode) || [], {})).replace(
+    /\s+\|\s+Quran Foundation Documentation Portal$/,
+    "",
+  );
+}
+
+function readMetaContent(document, metaName) {
+  const metaNode = findOne(
+    (node) =>
+      isTag(node) &&
+      node.name === "meta" &&
+      (getAttributeValue(node, "name") || "").toLowerCase() === metaName,
+    getChildren(document) || [],
+    true,
+  );
+
+  return metaNode ? getAttributeValue(metaNode, "content") || "" : "";
+}
+
+function renderNodes(nodes, context) {
+  return (nodes || []).map((node) => renderNode(node, context)).join("");
+}
+
+function renderNode(node, context) {
+  if (isText(node)) {
+    return context.inPre
+      ? node.data.replace(/\r\n?/g, "\n")
+      : normalizeText(node.data);
+  }
+
+  if (!isTag(node) || shouldSkipNode(node)) {
+    return "";
+  }
+
+  switch (node.name) {
+    case "a":
+      return renderLink(node, context);
+    case "blockquote":
+      return renderBlockquote(node, context);
+    case "br":
+      return context.inPre ? "\n" : "  \n";
+    case "code":
+      return context.inPre ? renderNodes(getChildren(node) || [], context) : renderInlineCode(node);
+    case "details":
+      return renderDetails(node, context);
+    case "dl":
+      return renderDescriptionList(node, context);
+    case "em":
+    case "i":
+      return wrapInline("*", renderNodes(getChildren(node) || [], context));
+    case "h1":
+    case "h2":
+    case "h3":
+    case "h4":
+    case "h5":
+    case "h6":
+      return renderHeading(node, Number(node.name.slice(1)), context);
+    case "hr":
+      return "\n---\n\n";
+    case "img":
+      return renderImage(node, context);
+    case "ol":
+      return renderList(node, true, context);
+    case "p":
+      return renderParagraph(node, context);
+    case "pre":
+      return renderCodeBlock(node, context);
+    case "strong":
+    case "b":
+      return wrapInline("**", renderNodes(getChildren(node) || [], context));
+    case "summary":
+      return "";
+    case "table":
+      return renderTable(node, context);
+    case "ul":
+      return renderList(node, false, context);
+    default:
+      return renderNodes(getChildren(node) || [], context);
+  }
+}
+
+function shouldSkipNode(node) {
+  if (!isTag(node)) {
+    return false;
+  }
+
+  if (SKIPPED_TAGS.has(node.name)) {
+    return true;
+  }
+
+  const className = getAttributeValue(node, "class") || "";
+  return SKIPPED_CLASS_PATTERNS.some((pattern) => pattern.test(className));
+}
+
+function renderHeading(node, level, context) {
+  const text = cleanupInline(renderNodes(getChildren(node) || [], context));
+  return text ? `${"#".repeat(level)} ${text}\n\n` : "";
+}
+
+function renderParagraph(node, context) {
+  const text = cleanupInline(renderNodes(getChildren(node) || [], context));
+  return text ? `${text}\n\n` : "";
+}
+
+function renderLink(node, context) {
+  const text = cleanupInline(renderNodes(getChildren(node) || [], context));
+  const href = resolveUrl(getAttributeValue(node, "href"), context.sourceUrl);
+
+  if (!href) {
+    return text;
+  }
+
+  const label = text || href;
+  return `[${label}](${href})`;
+}
+
+function renderImage(node, context) {
+  const src = resolveUrl(getAttributeValue(node, "src"), context.sourceUrl);
+  if (!src) {
+    return "";
+  }
+
+  const alt = cleanupInline(getAttributeValue(node, "alt") || "");
+  return `![${alt}](${src})`;
+}
+
+function renderInlineCode(node) {
+  const code = cleanupInline(collectText(node, { inPre: true })).replace(/\n+/g, " ");
+  if (!code) {
+    return "";
+  }
+
+  const fence = code.includes("`") ? "``" : "`";
+  return `${fence}${code}${fence}`;
+}
+
+function renderCodeBlock(node, context) {
+  const language = detectCodeLanguage(node);
+  const code = collectText(node, { ...context, inPre: true })
+    .replace(/\u00a0/g, " ")
+    .replace(/\r\n?/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+
+  if (!code.trim()) {
+    return "";
+  }
+
+  const languageSuffix = language || "";
+  return `\`\`\`${languageSuffix}\n${code}\n\`\`\`\n\n`;
+}
+
+function renderList(node, ordered, context) {
+  const items = (getChildren(node) || []).filter(
+    (child) => isTag(child) && child.name === "li",
+  );
+
+  if (items.length === 0) {
+    return "";
+  }
+
+  return (
+    items
+      .map((item, index) =>
+        renderListItem(item, {
+          ...context,
+          listDepth: context.listDepth || 0,
+          ordered,
+          ordinal: index + 1,
+        }),
+      )
+      .join("") + "\n"
+  );
+}
+
+function renderListItem(node, context) {
+  const indent = "  ".repeat(context.listDepth || 0);
+  const marker = context.ordered ? `${context.ordinal}. ` : "- ";
+  const content = [];
+  const nested = [];
+
+  for (const child of getChildren(node) || []) {
+    if (isTag(child) && (child.name === "ul" || child.name === "ol")) {
+      nested.push(
+        renderList(child, child.name === "ol", {
+          ...context,
+          listDepth: (context.listDepth || 0) + 1,
+        }).trimEnd(),
+      );
+      continue;
+    }
+
+    content.push(renderNode(child, context));
+  }
+
+  const itemText = cleanupInline(content.join(""));
+  const lines = itemText
+    ? itemText.split("\n").map((line) => line.trim()).filter(Boolean)
+    : [];
+
+  let markdown = `${indent}${marker}${lines.shift() || ""}\n`;
+  for (const line of lines) {
+    markdown += `${indent}  ${line}\n`;
+  }
+
+  if (nested.length > 0) {
+    markdown += `${nested.join("\n")}\n`;
+  }
+
+  return markdown;
+}
+
+function renderTable(node, context) {
+  const rows = [];
+
+  for (const child of getChildren(node) || []) {
+    if (!isTag(child)) {
+      continue;
+    }
+
+    if (child.name === "thead" || child.name === "tbody" || child.name === "tfoot") {
+      rows.push(...extractTableRows(child, context));
+      continue;
+    }
+
+    if (child.name === "tr") {
+      rows.push(renderTableRow(child, context));
+    }
+  }
+
+  const normalizedRows = rows.filter((row) => row.length > 0);
+  if (normalizedRows.length === 0) {
+    return "";
+  }
+
+  const header = normalizedRows[0];
+  const divider = header.map(() => "---");
+  const bodyRows = normalizedRows.slice(1);
+
+  const markdownRows = [
+    `| ${header.join(" | ")} |`,
+    `| ${divider.join(" | ")} |`,
+    ...bodyRows.map((row) => `| ${row.join(" | ")} |`),
+  ];
+
+  return `${markdownRows.join("\n")}\n\n`;
+}
+
+function extractTableRows(node, context) {
+  return (getChildren(node) || [])
+    .filter((child) => isTag(child) && child.name === "tr")
+    .map((row) => renderTableRow(row, context));
+}
+
+function renderTableRow(node, context) {
+  return (getChildren(node) || [])
+    .filter((child) => isTag(child) && (child.name === "th" || child.name === "td"))
+    .map((cell) =>
+      cleanupInline(renderNodes(getChildren(cell) || [], context))
+        .replace(/\|/g, "\\|")
+        .replace(/\n+/g, " <br> "),
+    );
+}
+
+function renderBlockquote(node, context) {
+  const content = cleanupMarkdown(renderNodes(getChildren(node) || [], context));
+  if (!content) {
+    return "";
+  }
+
+  return `${content
+    .split("\n")
+    .map((line) => (line ? `> ${line}` : ">"))
+    .join("\n")}\n\n`;
+}
+
+function renderDetails(node, context) {
+  const summaryNode = (getChildren(node) || []).find(
+    (child) => isTag(child) && child.name === "summary",
+  );
+  const summary = summaryNode
+    ? cleanupInline(renderNodes(getChildren(summaryNode) || [], context))
+    : "";
+  const content = cleanupMarkdown(
+    renderNodes(
+      (getChildren(node) || []).filter((child) => child !== summaryNode),
+      context,
+    ),
+  );
+
+  if (!summary && !content) {
+    return "";
+  }
+
+  const summaryLine = summary ? `**${summary}**\n\n` : "";
+  const contentBlock = content ? `${content}\n\n` : "";
+  return `${summaryLine}${contentBlock}`;
+}
+
+function renderDescriptionList(node, context) {
+  const parts = [];
+  let currentTerm = "";
+
+  for (const child of getChildren(node) || []) {
+    if (!isTag(child)) {
+      continue;
+    }
+
+    if (child.name === "dt") {
+      currentTerm = cleanupInline(renderNodes(getChildren(child) || [], context));
+      continue;
+    }
+
+    if (child.name === "dd") {
+      const description = cleanupInline(renderNodes(getChildren(child) || [], context));
+      if (currentTerm || description) {
+        parts.push(`- **${currentTerm || "Item"}**: ${description}`);
+      }
+    }
+  }
+
+  return parts.length > 0 ? `${parts.join("\n")}\n\n` : "";
+}
+
+function detectCodeLanguage(node) {
+  const candidates = [node, node.parent, node.parent && node.parent.parent].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const className = getAttributeValue(candidate, "class") || "";
+    const match = className.match(/language-([a-z0-9+-]+)/i);
+    if (match) {
+      return match[1].toLowerCase();
+    }
+  }
+
+  return "";
+}
+
+function collectText(node, context) {
+  if (isText(node)) {
+    return context.inPre ? node.data : normalizeText(node.data);
+  }
+
+  if (!isTag(node) || shouldSkipNode(node)) {
+    return "";
+  }
+
+  if (node.name === "br") {
+    return "\n";
+  }
+
+  return renderNodes(getChildren(node) || [], context);
+}
+
+function normalizeText(text) {
+  return text.replace(/\u200b/g, "").replace(/\s+/g, " ");
+}
+
+function cleanupInline(text) {
+  return text.replace(/\u200b/g, "").replace(/\s+/g, " ").trim();
+}
+
+function cleanupMarkdown(text) {
+  return text
+    .replace(/\u200b/g, "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{4,}/g, "\n\n\n")
+    .trim();
+}
+
+function resolveUrl(value, sourceUrl) {
+  if (!value) {
+    return "";
+  }
+
+  const trimmedValue = value.trim();
+  if (!trimmedValue || /^javascript:/i.test(trimmedValue)) {
+    return "";
+  }
+
+  try {
+    return new URL(trimmedValue, sourceUrl || BASE_URL).toString();
+  } catch (_error) {
+    return trimmedValue;
+  }
+}
+
+function wrapInline(wrapper, value) {
+  const text = cleanupInline(value);
+  return text ? `${wrapper}${text}${wrapper}` : "";
+}
+
+function quoteYaml(value) {
+  return JSON.stringify(value);
+}
+
+module.exports = {
+  BASE_URL,
+  buildMarkdownDocument,
+  exportMarkdownFiles,
+  toPublicUrl,
+};

--- a/src/markdown-negotiation-runtime.cjs
+++ b/src/markdown-negotiation-runtime.cjs
@@ -15,10 +15,18 @@ function withHeaders(response, headers, method) {
   });
 }
 
+function shouldRewriteMarkdownContentType(response) {
+  return response.ok && !isHtmlContentType(response.headers.get("Content-Type"));
+}
+
 async function negotiateMarkdownResponse({ assetsFetch, request, response }) {
   const url = new URL(request.url);
 
   if (isMarkdownPath(url.pathname)) {
+    if (!shouldRewriteMarkdownContentType(response)) {
+      return response;
+    }
+
     const headers = new Headers(response.headers);
     headers.set("Content-Type", MARKDOWN_CONTENT_TYPE);
     return withHeaders(response, headers, request.method);

--- a/src/markdown-negotiation-runtime.cjs
+++ b/src/markdown-negotiation-runtime.cjs
@@ -1,0 +1,62 @@
+const {
+  MARKDOWN_CONTENT_TYPE,
+  acceptsMarkdown,
+  appendHeaderValue,
+  isHtmlContentType,
+  isMarkdownPath,
+  toMarkdownAssetPath,
+} = require("./markdown-negotiation-shared.cjs");
+
+function withHeaders(response, headers, method) {
+  return new Response(method === "HEAD" ? null : response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+async function negotiateMarkdownResponse({ assetsFetch, request, response }) {
+  const url = new URL(request.url);
+
+  if (isMarkdownPath(url.pathname)) {
+    const headers = new Headers(response.headers);
+    headers.set("Content-Type", MARKDOWN_CONTENT_TYPE);
+    return withHeaders(response, headers, request.method);
+  }
+
+  if (!isHtmlContentType(response.headers.get("Content-Type"))) {
+    return response;
+  }
+
+  const htmlHeaders = new Headers(response.headers);
+  appendHeaderValue(htmlHeaders, "Vary", "Accept");
+
+  if (!acceptsMarkdown(request.headers.get("Accept"))) {
+    return withHeaders(response, htmlHeaders, request.method);
+  }
+
+  const markdownAssetPath = toMarkdownAssetPath(url.pathname);
+  if (!markdownAssetPath) {
+    return withHeaders(response, htmlHeaders, request.method);
+  }
+
+  const markdownRequest = new Request(new URL(markdownAssetPath, url), {
+    method: request.method,
+    headers: request.headers,
+  });
+  const markdownResponse = await assetsFetch(markdownRequest);
+
+  if (!markdownResponse.ok) {
+    return withHeaders(response, htmlHeaders, request.method);
+  }
+
+  const markdownHeaders = new Headers(markdownResponse.headers);
+  markdownHeaders.set("Content-Type", MARKDOWN_CONTENT_TYPE);
+  appendHeaderValue(markdownHeaders, "Vary", "Accept");
+
+  return withHeaders(markdownResponse, markdownHeaders, request.method);
+}
+
+module.exports = {
+  negotiateMarkdownResponse,
+};

--- a/src/markdown-negotiation-shared.cjs
+++ b/src/markdown-negotiation-shared.cjs
@@ -1,0 +1,84 @@
+const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+
+function acceptsMarkdown(acceptHeader) {
+  if (!acceptHeader) {
+    return false;
+  }
+
+  return acceptHeader.split(",").some((mediaRange) => {
+    const [type, ...params] = mediaRange.split(";").map((part) => part.trim());
+    if (type.toLowerCase() !== "text/markdown") {
+      return false;
+    }
+
+    const qParam = params.find((part) => part.toLowerCase().startsWith("q="));
+    if (!qParam) {
+      return true;
+    }
+
+    const quality = Number(qParam.slice(2));
+    return Number.isFinite(quality) && quality > 0;
+  });
+}
+
+function isHtmlContentType(contentType) {
+  return Boolean(contentType) && contentType.toLowerCase().startsWith("text/html");
+}
+
+function isMarkdownPath(pathname) {
+  return pathname.toLowerCase().endsWith(".md");
+}
+
+function toMarkdownAssetPath(pathname) {
+  if (!pathname) {
+    return "/index.md";
+  }
+
+  if (isMarkdownPath(pathname)) {
+    return pathname;
+  }
+
+  if (pathname === "/") {
+    return "/index.md";
+  }
+
+  if (pathname.endsWith("/")) {
+    return `${pathname}index.md`;
+  }
+
+  if (/\.[a-z0-9]+$/i.test(pathname)) {
+    return pathname.toLowerCase().endsWith(".html")
+      ? pathname.replace(/\.html$/i, ".md")
+      : null;
+  }
+
+  return `${pathname}/index.md`;
+}
+
+function appendHeaderValue(headers, name, value) {
+  const existing = headers.get(name);
+  if (!existing) {
+    headers.set(name, value);
+    return;
+  }
+
+  const values = existing
+    .split(",")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (values.includes(value.toLowerCase())) {
+    return;
+  }
+
+  headers.set(name, `${existing}, ${value}`);
+}
+
+module.exports = {
+  MARKDOWN_CONTENT_TYPE,
+  acceptsMarkdown,
+  appendHeaderValue,
+  isHtmlContentType,
+  isMarkdownPath,
+  toMarkdownAssetPath,
+};

--- a/tests/markdown-negotiation.test.cjs
+++ b/tests/markdown-negotiation.test.cjs
@@ -77,6 +77,24 @@ test("builds markdown from article content and preserves code blocks", () => {
   assert.doesNotMatch(markdown, /Ignore me/);
 });
 
+test("uses a longer inline fence when inline code contains repeated backticks", () => {
+  const markdown = buildMarkdown.buildMarkdownDocument({
+    html: [
+      "<!doctype html>",
+      "<html>",
+      "  <body>",
+      "    <article>",
+      "      <p><code>a``b</code></p>",
+      "    </article>",
+      "  </body>",
+      "</html>",
+    ].join("\n"),
+    sourceUrl: "https://api-docs.quran.foundation/docs/inline-code-example/",
+  });
+
+  assert.match(markdown, /```a``b```/);
+});
+
 test("uses a longer outer fence when code blocks contain triple backticks", () => {
   const markdown = buildMarkdown.buildMarkdownDocument({
     html: [

--- a/tests/markdown-negotiation.test.cjs
+++ b/tests/markdown-negotiation.test.cjs
@@ -1,0 +1,153 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const shared = require(path.join(
+  __dirname,
+  "..",
+  "src",
+  "markdown-negotiation-shared.cjs",
+));
+const buildMarkdown = require(path.join(
+  __dirname,
+  "..",
+  "src",
+  "build-markdown.cjs",
+));
+const runtime = require(path.join(
+  __dirname,
+  "..",
+  "src",
+  "markdown-negotiation-runtime.cjs",
+));
+
+test("detects explicit markdown negotiation requests", () => {
+  assert.equal(shared.acceptsMarkdown("text/html, text/markdown"), true);
+  assert.equal(shared.acceptsMarkdown("text/markdown;q=0"), false);
+  assert.equal(shared.acceptsMarkdown("text/html, application/xhtml+xml"), false);
+});
+
+test("maps routed pages to sibling markdown assets", () => {
+  assert.equal(shared.toMarkdownAssetPath("/"), "/index.md");
+  assert.equal(shared.toMarkdownAssetPath("/docs/quickstart/"), "/docs/quickstart/index.md");
+  assert.equal(shared.toMarkdownAssetPath("/docs/quickstart"), "/docs/quickstart/index.md");
+  assert.equal(shared.toMarkdownAssetPath("/404.html"), "/404.md");
+  assert.equal(shared.toMarkdownAssetPath("/robots.txt"), null);
+});
+
+test("builds markdown from article content and preserves code blocks", () => {
+  const markdown = buildMarkdown.buildMarkdownDocument({
+    html: `<!doctype html>
+      <html>
+        <head>
+          <title>Quickstart | Quran Foundation Documentation Portal</title>
+          <meta name="description" content="First request walkthrough">
+        </head>
+        <body>
+          <main>
+            <p>This should be ignored because article wins.</p>
+          </main>
+          <article>
+            <nav class="breadcrumbs">Ignore me</nav>
+            <header><h1>Quickstart</h1></header>
+            <p>Use <a href="/docs/reference/">the reference</a>.</p>
+            <pre class="language-bash"><code>curl https://example.com\n</code></pre>
+            <table>
+              <thead><tr><th>Item</th><th>Value</th></tr></thead>
+              <tbody><tr><td>Format</td><td>Markdown</td></tr></tbody>
+            </table>
+          </article>
+        </body>
+      </html>`,
+    sourceUrl: "https://api-docs.quran.foundation/docs/quickstart/",
+  });
+
+  assert.match(markdown, /title: "Quickstart"/);
+  assert.match(markdown, /source: "https:\/\/api-docs\.quran\.foundation\/docs\/quickstart\/"/);
+  assert.match(markdown, /# Quickstart/);
+  assert.match(
+    markdown,
+    /\[the reference\]\(https:\/\/api-docs\.quran\.foundation\/docs\/reference\/\)/,
+  );
+  assert.match(markdown, /```bash\ncurl https:\/\/example\.com\n```/);
+  assert.match(markdown, /\| Item \| Value \|/);
+  assert.doesNotMatch(markdown, /This should be ignored because article wins/);
+  assert.doesNotMatch(markdown, /Ignore me/);
+});
+
+test("exports markdown siblings next to generated html files", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qf-markdown-"));
+  const docsDir = path.join(tempDir, "docs", "quickstart");
+  fs.mkdirSync(docsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(docsDir, "index.html"),
+    `<!doctype html><html><head><title>Quickstart | Quran Foundation Documentation Portal</title></head><body><article><h1>Quickstart</h1><p>Hello world.</p></article></body></html>`,
+    "utf8",
+  );
+
+  const exportedCount = buildMarkdown.exportMarkdownFiles(tempDir);
+  const markdownPath = path.join(docsDir, "index.md");
+
+  assert.equal(exportedCount, 1);
+  assert.equal(fs.existsSync(markdownPath), true);
+  assert.match(fs.readFileSync(markdownPath, "utf8"), /# Quickstart/);
+});
+
+test("serves markdown with the negotiated content type while preserving HTML by default", async () => {
+  const request = new Request("https://api-docs.quran.foundation/docs/quickstart/", {
+    headers: {
+      Accept: "text/markdown, text/html;q=0.8",
+    },
+  });
+  const htmlResponse = new Response("<html><body><h1>Quickstart</h1></body></html>", {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+
+  const response = await runtime.negotiateMarkdownResponse({
+    assetsFetch: async (assetRequest) => {
+      assert.equal(assetRequest.url, "https://api-docs.quran.foundation/docs/quickstart/index.md");
+      return new Response("# Quickstart\n", {
+        headers: {
+          "Cache-Control": "public, max-age=0, must-revalidate",
+          "Content-Type": "text/plain; charset=utf-8",
+          "x-markdown-tokens": "42",
+        },
+      });
+    },
+    request,
+    response: htmlResponse,
+  });
+
+  assert.equal(response.headers.get("Content-Type"), shared.MARKDOWN_CONTENT_TYPE);
+  assert.match(response.headers.get("Vary"), /Accept/);
+  assert.equal(response.headers.get("x-markdown-tokens"), "42");
+  assert.equal(await response.text(), "# Quickstart\n");
+});
+
+test("keeps HTML as the default response for non-markdown clients", async () => {
+  const request = new Request("https://api-docs.quran.foundation/docs/quickstart/");
+  const htmlResponse = new Response("<html><body><h1>Quickstart</h1></body></html>", {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+
+  const response = await runtime.negotiateMarkdownResponse({
+    assetsFetch: async () => {
+      throw new Error("assets fetch should not run for default HTML requests");
+    },
+    request,
+    response: htmlResponse,
+  });
+
+  assert.equal(response.headers.get("Content-Type"), "text/html; charset=utf-8");
+  assert.match(response.headers.get("Vary"), /Accept/);
+  assert.equal(
+    await response.text(),
+    "<html><body><h1>Quickstart</h1></body></html>",
+  );
+});

--- a/tests/markdown-negotiation.test.cjs
+++ b/tests/markdown-negotiation.test.cjs
@@ -77,6 +77,27 @@ test("builds markdown from article content and preserves code blocks", () => {
   assert.doesNotMatch(markdown, /Ignore me/);
 });
 
+test("uses a longer outer fence when code blocks contain triple backticks", () => {
+  const markdown = buildMarkdown.buildMarkdownDocument({
+    html: [
+      "<!doctype html>",
+      "<html>",
+      "  <body>",
+      "    <article>",
+      "      <h1>Markdown Example</h1>",
+      "      <pre><code>```md",
+      "# Nested fence",
+      "```</code></pre>",
+      "    </article>",
+      "  </body>",
+      "</html>",
+    ].join("\n"),
+    sourceUrl: "https://api-docs.quran.foundation/docs/markdown-example/",
+  });
+
+  assert.match(markdown, /````\n```md\n# Nested fence\n```\n````/);
+});
+
 test("exports markdown siblings next to generated html files", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "qf-markdown-"));
   const docsDir = path.join(tempDir, "docs", "quickstart");
@@ -126,6 +147,31 @@ test("serves markdown with the negotiated content type while preserving HTML by 
   assert.match(response.headers.get("Vary"), /Accept/);
   assert.equal(response.headers.get("x-markdown-tokens"), "42");
   assert.equal(await response.text(), "# Quickstart\n");
+});
+
+test("keeps direct .md requests as HTML when the response is an HTML error page", async () => {
+  const request = new Request("https://api-docs.quran.foundation/docs/missing/index.md");
+  const html404 = new Response("<html><body><h1>Not Found</h1></body></html>", {
+    status: 404,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+
+  const response = await runtime.negotiateMarkdownResponse({
+    assetsFetch: async () => {
+      throw new Error("assets fetch should not run for direct .md requests");
+    },
+    request,
+    response: html404,
+  });
+
+  assert.equal(response.status, 404);
+  assert.equal(response.headers.get("Content-Type"), "text/html; charset=utf-8");
+  assert.equal(
+    await response.text(),
+    "<html><body><h1>Not Found</h1></body></html>",
+  );
 });
 
 test("keeps HTML as the default response for non-markdown clients", async () => {


### PR DESCRIPTION
## What changed
- generate markdown siblings for built HTML pages during the docs build
- add Cloudflare Pages middleware to serve markdown when requests send `Accept: text/markdown`
- keep HTML as the default response for browser requests and preserve `Vary: Accept`
- declare the HTML parsing libraries as build-only dependencies
- add tests for markdown asset generation and response negotiation

## Why
The site served HTML only, so agent clients requesting markdown could not negotiate a markdown representation of the docs. This change adds explicit markdown-for-agents handling without changing the default browser behavior.

## Impact
Agents and other markdown-capable clients can request docs as markdown with `Content-Type: text/markdown`, while normal browser traffic continues to receive HTML.

## Root cause
The docs build emitted only HTML and the Cloudflare runtime had no content negotiation path for markdown requests.

## Validation
- `node --test tests\\api-demo-panel-ui.test.cjs tests\\prelive-docs-config.test.cjs tests\\user-related-env-paths.test.cjs tests\\user-related-env-ui.test.cjs tests\\markdown-negotiation.test.cjs`
- `yarn install --frozen-lockfile --ignore-engines`
