### PR TITLE
[codex] add content signals to robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Disallow: /search
 Disallow: /request-scopes


### PR DESCRIPTION
## Summary
- add a site-wide `Content-Signal` directive to `robots.txt`
- keep the existing crawl rules and sitemap entry unchanged

## Why
- declare AI content usage preferences for training, search, and AI input
- address the missing Content Signals directive reported for the site

## Impact
- crawlers that support Content Signals can see that the docs allow search and AI input, but disallow AI training
- existing `Allow`, `Disallow`, and `Sitemap` behavior is unchanged

## Validation
- inspected `git diff -- static/robots.txt`
- ran `git diff --check`
