### PR TITLE
[codex] fix markdown accept negotiation

### DIFF
--- a/src/markdown-negotiation-runtime.cjs
+++ b/src/markdown-negotiation-runtime.cjs
@@ -125,6 +125,10 @@ async function negotiateMarkdownResponse({ assetsFetch, request, response }) {
   const markdownResponse = await assetsFetch(markdownRequest);
 
   if (!markdownResponse.ok) {
+    if (!response.ok) {
+      return withHeaders(response, htmlHeaders, request.method);
+    }
+
     if (preferredRepresentations.includes(HTML_MEDIA_TYPE)) {
       return withHeaders(response, htmlHeaders, request.method);
     }

--- a/src/markdown-negotiation-runtime.cjs
+++ b/src/markdown-negotiation-runtime.cjs
@@ -21,8 +21,31 @@ function shouldRewriteMarkdownContentType(response) {
   return response.ok && !isHtmlContentType(response.headers.get("Content-Type"));
 }
 
+const PASSTHROUGH_406_HEADERS = [
+  "Access-Control-Allow-Origin",
+  "Access-Control-Allow-Credentials",
+  "Access-Control-Expose-Headers",
+  "Content-Security-Policy",
+  "Link",
+  "Permissions-Policy",
+  "Referrer-Policy",
+  "Report-To",
+  "Strict-Transport-Security",
+  "X-Content-Type-Options",
+  "X-Frame-Options",
+  "X-Robots-Tag",
+  "X-XSS-Protection",
+];
+
 function notAcceptableResponse({ acceptHeader, method, response }) {
-  const headers = new Headers(response.headers);
+  const headers = new Headers();
+  for (const headerName of PASSTHROUGH_406_HEADERS) {
+    const headerValue = response.headers.get(headerName);
+    if (headerValue) {
+      headers.set(headerName, headerValue);
+    }
+  }
+
   headers.set("Cache-Control", "no-store");
   headers.set("Content-Type", "text/plain; charset=utf-8");
   appendHeaderValue(headers, "Vary", "Accept");

--- a/src/markdown-negotiation-runtime.cjs
+++ b/src/markdown-negotiation-runtime.cjs
@@ -1,9 +1,11 @@
 const {
+  HTML_MEDIA_TYPE,
   MARKDOWN_CONTENT_TYPE,
-  acceptsMarkdown,
+  MARKDOWN_MEDIA_TYPE,
   appendHeaderValue,
   isHtmlContentType,
   isMarkdownPath,
+  rankRepresentationTypes,
   toMarkdownAssetPath,
 } = require("./markdown-negotiation-shared.cjs");
 
@@ -19,8 +21,32 @@ function shouldRewriteMarkdownContentType(response) {
   return response.ok && !isHtmlContentType(response.headers.get("Content-Type"));
 }
 
+function notAcceptableResponse({ acceptHeader, method, response }) {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.set("Content-Type", "text/plain; charset=utf-8");
+  appendHeaderValue(headers, "Vary", "Accept");
+
+  const lines = [
+    "This resource is available in:",
+    `- ${HTML_MEDIA_TYPE}`,
+    `- ${MARKDOWN_MEDIA_TYPE}`,
+  ];
+
+  if (acceptHeader) {
+    lines.push("", `You requested: ${acceptHeader}`);
+  }
+
+  return new Response(method === "HEAD" ? null : lines.join("\n"), {
+    headers,
+    status: 406,
+    statusText: "Not Acceptable",
+  });
+}
+
 async function negotiateMarkdownResponse({ assetsFetch, request, response }) {
   const url = new URL(request.url);
+  const acceptHeader = request.headers.get("Accept");
 
   if (isMarkdownPath(url.pathname)) {
     if (!shouldRewriteMarkdownContentType(response)) {
@@ -36,16 +62,37 @@ async function negotiateMarkdownResponse({ assetsFetch, request, response }) {
     return response;
   }
 
+  const preferredRepresentations = rankRepresentationTypes(
+    acceptHeader,
+    [HTML_MEDIA_TYPE, MARKDOWN_MEDIA_TYPE],
+    HTML_MEDIA_TYPE,
+  );
+  if (!preferredRepresentations.length) {
+    return notAcceptableResponse({
+      acceptHeader,
+      method: request.method,
+      response,
+    });
+  }
+
   const htmlHeaders = new Headers(response.headers);
   appendHeaderValue(htmlHeaders, "Vary", "Accept");
 
-  if (!acceptsMarkdown(request.headers.get("Accept"))) {
+  if (preferredRepresentations[0] === HTML_MEDIA_TYPE) {
     return withHeaders(response, htmlHeaders, request.method);
   }
 
   const markdownAssetPath = toMarkdownAssetPath(url.pathname);
   if (!markdownAssetPath) {
-    return withHeaders(response, htmlHeaders, request.method);
+    if (preferredRepresentations.includes(HTML_MEDIA_TYPE)) {
+      return withHeaders(response, htmlHeaders, request.method);
+    }
+
+    return notAcceptableResponse({
+      acceptHeader,
+      method: request.method,
+      response,
+    });
   }
 
   const markdownRequest = new Request(new URL(markdownAssetPath, url), {
@@ -55,7 +102,15 @@ async function negotiateMarkdownResponse({ assetsFetch, request, response }) {
   const markdownResponse = await assetsFetch(markdownRequest);
 
   if (!markdownResponse.ok) {
-    return withHeaders(response, htmlHeaders, request.method);
+    if (preferredRepresentations.includes(HTML_MEDIA_TYPE)) {
+      return withHeaders(response, htmlHeaders, request.method);
+    }
+
+    return notAcceptableResponse({
+      acceptHeader,
+      method: request.method,
+      response,
+    });
   }
 
   const markdownHeaders = new Headers(markdownResponse.headers);

--- a/src/markdown-negotiation-shared.cjs
+++ b/src/markdown-negotiation-shared.cjs
@@ -1,24 +1,149 @@
-const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+const HTML_MEDIA_TYPE = "text/html";
+const MARKDOWN_MEDIA_TYPE = "text/markdown";
+const MARKDOWN_CONTENT_TYPE = `${MARKDOWN_MEDIA_TYPE}; charset=utf-8`;
 
-function acceptsMarkdown(acceptHeader) {
-  if (!acceptHeader) {
-    return false;
+function parseAcceptEntries(acceptHeader) {
+  if (!acceptHeader || !acceptHeader.trim()) {
+    return [];
   }
 
-  return acceptHeader.split(",").some((mediaRange) => {
-    const [type, ...params] = mediaRange.split(";").map((part) => part.trim());
-    if (type.toLowerCase() !== "text/markdown") {
-      return false;
+  return acceptHeader
+    .split(",")
+    .map((mediaRange, order) => {
+      const [type, ...params] = mediaRange.split(";").map((part) => part.trim());
+      if (!type || !type.includes("/")) {
+        return null;
+      }
+
+      const qParam = params.find((part) => part.toLowerCase().startsWith("q="));
+      const quality = qParam ? Number(qParam.slice(2)) : 1;
+      const q =
+        Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0;
+
+      return {
+        order,
+        q,
+        type: type.toLowerCase(),
+      };
+    })
+    .filter(Boolean);
+}
+
+function getMediaRangeSpecificity(candidateType, mediaRangeType) {
+  const [candidatePrimaryType, candidateSubtype] = candidateType.split("/");
+  const [rangePrimaryType, rangeSubtype] = mediaRangeType.split("/");
+
+  if (!candidatePrimaryType || !candidateSubtype || !rangePrimaryType || !rangeSubtype) {
+    return -1;
+  }
+
+  if (rangePrimaryType === "*" && rangeSubtype === "*") {
+    return 0;
+  }
+
+  if (rangeSubtype === "*" && rangePrimaryType === candidatePrimaryType) {
+    return 1;
+  }
+
+  if (rangePrimaryType === candidatePrimaryType && rangeSubtype === candidateSubtype) {
+    return 2;
+  }
+
+  return -1;
+}
+
+function getRepresentationRank(representationType, acceptEntries) {
+  let bestMatch = null;
+
+  for (const entry of acceptEntries) {
+    const specificity = getMediaRangeSpecificity(representationType, entry.type);
+    if (specificity === -1) {
+      continue;
     }
 
-    const qParam = params.find((part) => part.toLowerCase().startsWith("q="));
-    if (!qParam) {
-      return true;
+    if (
+      !bestMatch ||
+      specificity > bestMatch.specificity ||
+      (specificity === bestMatch.specificity && entry.q > bestMatch.q) ||
+      (specificity === bestMatch.specificity &&
+        entry.q === bestMatch.q &&
+        entry.order < bestMatch.order)
+    ) {
+      bestMatch = {
+        order: entry.order,
+        q: entry.q,
+        specificity,
+      };
     }
+  }
 
-    const quality = Number(qParam.slice(2));
-    return Number.isFinite(quality) && quality > 0;
-  });
+  if (!bestMatch) {
+    return {
+      order: Number.POSITIVE_INFINITY,
+      q: 0,
+      specificity: -1,
+    };
+  }
+
+  return bestMatch;
+}
+
+function rankRepresentationTypes(
+  acceptHeader,
+  availableTypes,
+  defaultType = availableTypes[0],
+) {
+  const normalizedAvailableTypes = availableTypes.map((type) => type.toLowerCase());
+  const normalizedDefaultType = defaultType.toLowerCase();
+  const acceptEntries = parseAcceptEntries(acceptHeader);
+
+  if (!acceptEntries.length) {
+    return normalizedAvailableTypes
+      .slice()
+      .sort((a, b) => {
+        if (a === normalizedDefaultType) {
+          return -1;
+        }
+
+        if (b === normalizedDefaultType) {
+          return 1;
+        }
+
+        return normalizedAvailableTypes.indexOf(a) - normalizedAvailableTypes.indexOf(b);
+      });
+  }
+
+  return normalizedAvailableTypes
+    .map((type, index) => ({
+      index,
+      type,
+      ...getRepresentationRank(type, acceptEntries),
+    }))
+    .filter((entry) => entry.q > 0)
+    .sort((a, b) => {
+      if (b.q !== a.q) {
+        return b.q - a.q;
+      }
+
+      if (b.specificity !== a.specificity) {
+        return b.specificity - a.specificity;
+      }
+
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+
+      if (a.type === normalizedDefaultType) {
+        return -1;
+      }
+
+      if (b.type === normalizedDefaultType) {
+        return 1;
+      }
+
+      return a.index - b.index;
+    })
+    .map((entry) => entry.type);
 }
 
 function isHtmlContentType(contentType) {
@@ -75,10 +200,12 @@ function appendHeaderValue(headers, name, value) {
 }
 
 module.exports = {
+  HTML_MEDIA_TYPE,
   MARKDOWN_CONTENT_TYPE,
-  acceptsMarkdown,
+  MARKDOWN_MEDIA_TYPE,
   appendHeaderValue,
   isHtmlContentType,
   isMarkdownPath,
+  rankRepresentationTypes,
   toMarkdownAssetPath,
 };

--- a/tests/markdown-negotiation.test.cjs
+++ b/tests/markdown-negotiation.test.cjs
@@ -289,7 +289,11 @@ test("returns 406 when the Accept header rejects both HTML and markdown", async 
   });
   const htmlResponse = new Response("<html><body><h1>Quickstart</h1></body></html>", {
     headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Content-Encoding": "gzip",
       "Content-Type": "text/html; charset=utf-8",
+      ETag: "\"html-etag\"",
+      Link: "</llms.txt>; rel=\"describedby\"; type=\"text/plain\"",
       "x-frame-options": "SAMEORIGIN",
     },
   });
@@ -303,8 +307,16 @@ test("returns 406 when the Accept header rejects both HTML and markdown", async 
   });
 
   assert.equal(response.status, 406);
+  assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
   assert.equal(response.headers.get("Content-Type"), "text/plain; charset=utf-8");
   assert.equal(response.headers.get("Cache-Control"), "no-store");
+  assert.equal(response.headers.get("Content-Encoding"), null);
+  assert.equal(response.headers.get("Content-Length"), null);
+  assert.equal(response.headers.get("ETag"), null);
+  assert.equal(
+    response.headers.get("Link"),
+    "</llms.txt>; rel=\"describedby\"; type=\"text/plain\"",
+  );
   assert.equal(response.headers.get("x-frame-options"), "SAMEORIGIN");
   assert.match(response.headers.get("Vary"), /Accept/);
 

--- a/tests/markdown-negotiation.test.cjs
+++ b/tests/markdown-negotiation.test.cjs
@@ -23,10 +23,47 @@ const runtime = require(path.join(
   "markdown-negotiation-runtime.cjs",
 ));
 
-test("detects explicit markdown negotiation requests", () => {
-  assert.equal(shared.acceptsMarkdown("text/html, text/markdown"), true);
-  assert.equal(shared.acceptsMarkdown("text/markdown;q=0"), false);
-  assert.equal(shared.acceptsMarkdown("text/html, application/xhtml+xml"), false);
+test("ranks supported representations from the Accept header", () => {
+  assert.deepEqual(
+    shared.rankRepresentationTypes(
+      "text/markdown, text/html;q=0.8",
+      [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+      shared.HTML_MEDIA_TYPE,
+    ),
+    [shared.MARKDOWN_MEDIA_TYPE, shared.HTML_MEDIA_TYPE],
+  );
+  assert.deepEqual(
+    shared.rankRepresentationTypes(
+      "text/html, text/markdown;q=0.5",
+      [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+      shared.HTML_MEDIA_TYPE,
+    ),
+    [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+  );
+  assert.deepEqual(
+    shared.rankRepresentationTypes(
+      "text/*;q=0.7, text/html;q=0",
+      [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+      shared.HTML_MEDIA_TYPE,
+    ),
+    [shared.MARKDOWN_MEDIA_TYPE],
+  );
+  assert.deepEqual(
+    shared.rankRepresentationTypes(
+      "application/x-content-negotiation-probe",
+      [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+      shared.HTML_MEDIA_TYPE,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    shared.rankRepresentationTypes(
+      undefined,
+      [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+      shared.HTML_MEDIA_TYPE,
+    ),
+    [shared.HTML_MEDIA_TYPE, shared.MARKDOWN_MEDIA_TYPE],
+  );
 });
 
 test("maps routed pages to sibling markdown assets", () => {
@@ -214,4 +251,66 @@ test("keeps HTML as the default response for non-markdown clients", async () => 
     await response.text(),
     "<html><body><h1>Quickstart</h1></body></html>",
   );
+});
+
+test("honors q-values when HTML is preferred over markdown", async () => {
+  const request = new Request("https://api-docs.quran.foundation/docs/quickstart/", {
+    headers: {
+      Accept: "text/html, text/markdown;q=0.5",
+    },
+  });
+  const htmlResponse = new Response("<html><body><h1>Quickstart</h1></body></html>", {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+
+  const response = await runtime.negotiateMarkdownResponse({
+    assetsFetch: async () => {
+      throw new Error("assets fetch should not run when HTML is preferred");
+    },
+    request,
+    response: htmlResponse,
+  });
+
+  assert.equal(response.headers.get("Content-Type"), "text/html; charset=utf-8");
+  assert.match(response.headers.get("Vary"), /Accept/);
+  assert.equal(
+    await response.text(),
+    "<html><body><h1>Quickstart</h1></body></html>",
+  );
+});
+
+test("returns 406 when the Accept header rejects both HTML and markdown", async () => {
+  const request = new Request("https://api-docs.quran.foundation/docs/quickstart/", {
+    headers: {
+      Accept: "application/x-content-negotiation-probe",
+    },
+  });
+  const htmlResponse = new Response("<html><body><h1>Quickstart</h1></body></html>", {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "x-frame-options": "SAMEORIGIN",
+    },
+  });
+
+  const response = await runtime.negotiateMarkdownResponse({
+    assetsFetch: async () => {
+      throw new Error("assets fetch should not run for unsupported Accept types");
+    },
+    request,
+    response: htmlResponse,
+  });
+
+  assert.equal(response.status, 406);
+  assert.equal(response.headers.get("Content-Type"), "text/plain; charset=utf-8");
+  assert.equal(response.headers.get("Cache-Control"), "no-store");
+  assert.equal(response.headers.get("x-frame-options"), "SAMEORIGIN");
+  assert.match(response.headers.get("Vary"), /Accept/);
+
+  const body = await response.text();
+  assert.match(body, /This resource is available in:/);
+  assert.match(body, /text\/html/);
+  assert.match(body, /text\/markdown/);
+  assert.match(body, /application\/x-content-negotiation-probe/);
 });

--- a/tests/markdown-negotiation.test.cjs
+++ b/tests/markdown-negotiation.test.cjs
@@ -229,6 +229,42 @@ test("keeps direct .md requests as HTML when the response is an HTML error page"
   );
 });
 
+test("preserves origin 404 responses when markdown-only negotiation hits a missing route", async () => {
+  const request = new Request("https://api-docs.quran.foundation/docs/missing/", {
+    headers: {
+      Accept: "text/markdown",
+    },
+  });
+  const html404 = new Response("<html><body><h1>Not Found</h1></body></html>", {
+    status: 404,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+
+  const response = await runtime.negotiateMarkdownResponse({
+    assetsFetch: async (assetRequest) => {
+      assert.equal(assetRequest.url, "https://api-docs.quran.foundation/docs/missing/index.md");
+      return new Response("missing markdown sibling", {
+        status: 404,
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+        },
+      });
+    },
+    request,
+    response: html404,
+  });
+
+  assert.equal(response.status, 404);
+  assert.equal(response.headers.get("Content-Type"), "text/html; charset=utf-8");
+  assert.match(response.headers.get("Vary"), /Accept/);
+  assert.equal(
+    await response.text(),
+    "<html><body><h1>Not Found</h1></body></html>",
+  );
+});
+
 test("keeps HTML as the default response for non-markdown clients", async () => {
   const request = new Request("https://api-docs.quran.foundation/docs/quickstart/");
   const htmlResponse = new Response("<html><body><h1>Quickstart</h1></body></html>", {


### PR DESCRIPTION
## What changed

- replaced the boolean markdown check with proper `Accept` negotiation between `text/html` and `text/markdown`
- honor `q` values and `q=0` when ranking supported representations
- return `406 Not Acceptable` only when the client rejects both HTML and Markdown
- added regression tests for HTML-preferred requests and unsupported-only `Accept` headers

## Why this changed

The docs site was scoring `75/100` on acceptmarkdown.com because it always served Markdown whenever `text/markdown` appeared anywhere in the `Accept` header, even when HTML had a higher preference, and it silently fell back to HTML for unsupported types instead of returning `406`.

## Impact

- browsers and general clients still default to HTML
- agent clients that explicitly prefer Markdown still receive Markdown
- restrictive unsupported `Accept` headers now get a standards-correct `406` response instead of a silent HTML fallback

## Root cause

The edge middleware only answered ?does this request mention `text/markdown` with `q > 0`?? rather than performing best-match content negotiation across the representations the site can actually serve.

## Validation

- `NODE_PATH=C:\Code\qf-api-docs\node_modules C:\Users\Basit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test tests\markdown-negotiation.test.cjs`
- `NODE_PATH=C:\Code\qf-api-docs\node_modules C:\Users\Basit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test tests\*.test.cjs`
