### PR TITLE
[codex] Fix user API environment toggle paths

### DIFF
--- a/src/components/UserRelatedApiEnvironmentNotice/paths.js
+++ b/src/components/UserRelatedApiEnvironmentNotice/paths.js
@@ -1,11 +1,17 @@
 const PROD_CATEGORY_PATH = '/docs/category/user-related-apis';
 const PRELIVE_CATEGORY_PATH = '/docs/category/user-related-apis-pre-live';
-const PROD_LATEST_PREFIX = '/docs/user_related_apis_versioned/';
-const PRELIVE_PREFIX = '/docs/user_related_apis_prelive/';
+const PROD_LATEST_ROOT = '/docs/user_related_apis_versioned';
+const PRELIVE_ROOT = '/docs/user_related_apis_prelive';
+const PROD_LATEST_PREFIX = `${PROD_LATEST_ROOT}/`;
+const PRELIVE_PREFIX = `${PRELIVE_ROOT}/`;
 const PROD_VERSION_PREFIX_REGEX = /^\d+\.\d+\.\d+(\/|$)/;
 
 const normalizePath = (value) =>
   value && value !== '/' ? value.replace(/\/+$/, '') : value;
+const isPathInTree = (pathname, rootPath) =>
+  pathname === rootPath || pathname.startsWith(`${rootPath}/`);
+const isApiTreeRoot = (pathname) =>
+  pathname === PROD_LATEST_ROOT || pathname === PRELIVE_ROOT;
 const hasAvailablePath = (availablePaths, targetPath) => {
   const normalizedTargetPath = normalizePath(targetPath);
 
@@ -39,14 +45,14 @@ function getUserRelatedDocsEnvironment(pathname) {
 
   if (
     normalizedPathname === PROD_CATEGORY_PATH ||
-    normalizedPathname.startsWith(PROD_LATEST_PREFIX)
+    isPathInTree(normalizedPathname, PROD_LATEST_ROOT)
   ) {
     return 'production';
   }
 
   if (
     normalizedPathname === PRELIVE_CATEGORY_PATH ||
-    normalizedPathname.startsWith(PRELIVE_PREFIX)
+    isPathInTree(normalizedPathname, PRELIVE_ROOT)
   ) {
     return 'pre-live';
   }
@@ -70,17 +76,25 @@ function getTargetPath(pathname, targetEnvironment) {
   if (targetEnvironment === 'production') {
     if (normalizedPathname === PRELIVE_CATEGORY_PATH) {
       targetPath = PROD_CATEGORY_PATH;
-    } else if (normalizedPathname.startsWith(PRELIVE_PREFIX)) {
-      targetPath = `${PROD_LATEST_PREFIX}${stripPrefix(normalizedPathname, PRELIVE_PREFIX)}`;
+    } else if (isPathInTree(normalizedPathname, PRELIVE_ROOT)) {
+      targetPath =
+        normalizedPathname === PRELIVE_ROOT
+          ? PROD_LATEST_ROOT
+          : `${PROD_LATEST_PREFIX}${stripPrefix(normalizedPathname, PRELIVE_PREFIX)}`;
     }
   } else if (targetEnvironment === 'pre-live') {
     if (normalizedPathname === PROD_CATEGORY_PATH) {
       targetPath = PRELIVE_CATEGORY_PATH;
-    } else if (normalizedPathname.startsWith(PROD_LATEST_PREFIX)) {
-      const relativePath = stripPrefix(normalizedPathname, PROD_LATEST_PREFIX);
+    } else if (isPathInTree(normalizedPathname, PROD_LATEST_ROOT)) {
+      const relativePath =
+        normalizedPathname === PROD_LATEST_ROOT
+          ? ''
+          : stripPrefix(normalizedPathname, PROD_LATEST_PREFIX);
       const normalizedRelativePath = relativePath.replace(PROD_VERSION_PREFIX_REGEX, '');
 
-      targetPath = `${PRELIVE_PREFIX}${normalizedRelativePath}`;
+      targetPath = normalizedRelativePath
+        ? `${PRELIVE_PREFIX}${normalizedRelativePath}`
+        : PRELIVE_ROOT;
     }
   } else {
     return {
@@ -97,7 +111,7 @@ function getTargetPath(pathname, targetEnvironment) {
 
 function getUserRelatedDocsTarget(pathname, targetEnvironment, options = {}) {
   const { fallbackPath, targetPath } = getTargetPath(pathname, targetEnvironment);
-  const hasExplicitDocTarget = targetPath !== fallbackPath;
+  const hasExplicitDocTarget = targetPath !== fallbackPath && !isApiTreeRoot(targetPath);
   const hasEquivalentDoc = !hasExplicitDocTarget || !options.availablePaths
     ? true
     : hasAvailablePath(options.availablePaths, targetPath);

--- a/src/components/UserRelatedApiEnvironmentNotice/paths.js
+++ b/src/components/UserRelatedApiEnvironmentNotice/paths.js
@@ -4,6 +4,16 @@ const PROD_LATEST_PREFIX = '/docs/user_related_apis_versioned/';
 const PRELIVE_PREFIX = '/docs/user_related_apis_prelive/';
 const PROD_VERSION_PREFIX_REGEX = /^\d+\.\d+\.\d+(\/|$)/;
 
+const normalizePath = (value) =>
+  value && value !== '/' ? value.replace(/\/+$/, '') : value;
+const hasAvailablePath = (availablePaths, targetPath) => {
+  const normalizedTargetPath = normalizePath(targetPath);
+
+  return (
+    availablePaths.has(normalizedTargetPath) ||
+    availablePaths.has(`${normalizedTargetPath}/`)
+  );
+};
 const stripPrefix = (value, prefix) => value.slice(prefix.length);
 const getFallbackPath = (environment) =>
   environment === 'production' ? PROD_CATEGORY_PATH : PRELIVE_CATEGORY_PATH;
@@ -15,7 +25,7 @@ function getUserRelatedDocsAvailablePaths(allDocsData) {
     pluginData?.versions?.forEach((version) => {
       version?.docs?.forEach((doc) => {
         if (typeof doc?.path === 'string') {
-          paths.add(doc.path);
+          paths.add(normalizePath(doc.path));
         }
       });
     });
@@ -25,16 +35,18 @@ function getUserRelatedDocsAvailablePaths(allDocsData) {
 }
 
 function getUserRelatedDocsEnvironment(pathname) {
+  const normalizedPathname = normalizePath(pathname);
+
   if (
-    pathname === PROD_CATEGORY_PATH ||
-    pathname.startsWith(PROD_LATEST_PREFIX)
+    normalizedPathname === PROD_CATEGORY_PATH ||
+    normalizedPathname.startsWith(PROD_LATEST_PREFIX)
   ) {
     return 'production';
   }
 
   if (
-    pathname === PRELIVE_CATEGORY_PATH ||
-    pathname.startsWith(PRELIVE_PREFIX)
+    normalizedPathname === PRELIVE_CATEGORY_PATH ||
+    normalizedPathname.startsWith(PRELIVE_PREFIX)
   ) {
     return 'pre-live';
   }
@@ -43,36 +55,37 @@ function getUserRelatedDocsEnvironment(pathname) {
 }
 
 function getTargetPath(pathname, targetEnvironment) {
-  const currentEnvironment = getUserRelatedDocsEnvironment(pathname);
+  const normalizedPathname = normalizePath(pathname);
+  const currentEnvironment = getUserRelatedDocsEnvironment(normalizedPathname);
   const fallbackPath = getFallbackPath(targetEnvironment);
   let targetPath = fallbackPath;
 
   if (currentEnvironment && currentEnvironment === targetEnvironment) {
     return {
       fallbackPath,
-      targetPath: pathname,
+      targetPath: normalizedPathname,
     };
   }
 
   if (targetEnvironment === 'production') {
-    if (pathname === PRELIVE_CATEGORY_PATH) {
+    if (normalizedPathname === PRELIVE_CATEGORY_PATH) {
       targetPath = PROD_CATEGORY_PATH;
-    } else if (pathname.startsWith(PRELIVE_PREFIX)) {
-      targetPath = `${PROD_LATEST_PREFIX}${stripPrefix(pathname, PRELIVE_PREFIX)}`;
+    } else if (normalizedPathname.startsWith(PRELIVE_PREFIX)) {
+      targetPath = `${PROD_LATEST_PREFIX}${stripPrefix(normalizedPathname, PRELIVE_PREFIX)}`;
     }
   } else if (targetEnvironment === 'pre-live') {
-    if (pathname === PROD_CATEGORY_PATH) {
+    if (normalizedPathname === PROD_CATEGORY_PATH) {
       targetPath = PRELIVE_CATEGORY_PATH;
-    } else if (pathname.startsWith(PROD_LATEST_PREFIX)) {
-      const relativePath = stripPrefix(pathname, PROD_LATEST_PREFIX);
+    } else if (normalizedPathname.startsWith(PROD_LATEST_PREFIX)) {
+      const relativePath = stripPrefix(normalizedPathname, PROD_LATEST_PREFIX);
       const normalizedRelativePath = relativePath.replace(PROD_VERSION_PREFIX_REGEX, '');
 
       targetPath = `${PRELIVE_PREFIX}${normalizedRelativePath}`;
     }
   } else {
     return {
-      fallbackPath: pathname,
-      targetPath: pathname,
+      fallbackPath: normalizedPathname,
+      targetPath: normalizedPathname,
     };
   }
 
@@ -87,7 +100,7 @@ function getUserRelatedDocsTarget(pathname, targetEnvironment, options = {}) {
   const hasExplicitDocTarget = targetPath !== fallbackPath;
   const hasEquivalentDoc = !hasExplicitDocTarget || !options.availablePaths
     ? true
-    : options.availablePaths.has(targetPath);
+    : hasAvailablePath(options.availablePaths, targetPath);
   const path = hasEquivalentDoc ? targetPath : fallbackPath;
 
   return {

--- a/tests/user-related-env-paths.test.cjs
+++ b/tests/user-related-env-paths.test.cjs
@@ -33,6 +33,10 @@ test('detects production and pre-live user-related docs routes', () => {
     getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive/get-user-profile/'),
     'pre-live',
   );
+  assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_versioned'), 'production');
+  assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_versioned/'), 'production');
+  assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive'), 'pre-live');
+  assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive/'), 'pre-live');
   assert.equal(getUserRelatedDocsEnvironment('/docs/category/user-related-apis'), 'production');
   assert.equal(
     getUserRelatedDocsEnvironment('/docs/category/user-related-apis/'),
@@ -108,6 +112,14 @@ test('maps the current doc route between production and pre-live trees', () => {
     '/docs/category/user-related-apis-pre-live',
   );
   assert.equal(
+    getUserRelatedDocsPath('/docs/user_related_apis_versioned/', 'pre-live'),
+    '/docs/user_related_apis_prelive',
+  );
+  assert.equal(
+    getUserRelatedDocsPath('/docs/user_related_apis_prelive/', 'production'),
+    '/docs/user_related_apis_versioned',
+  );
+  assert.equal(
     getUserRelatedDocsPath('/docs/category/user-related-apis-pre-live', 'production'),
     '/docs/category/user-related-apis',
   );
@@ -170,6 +182,14 @@ test('falls back to the environment category when the target doc does not exist'
   );
   assert.equal(trailingSlashTarget.path, '/docs/user_related_apis_versioned/get-user-profile');
   assert.equal(trailingSlashTarget.hasEquivalentDoc, true);
+
+  const rootTarget = getUserRelatedDocsTarget(
+    '/docs/user_related_apis_versioned/',
+    'pre-live',
+    { availablePaths },
+  );
+  assert.equal(rootTarget.path, '/docs/user_related_apis_prelive');
+  assert.equal(rootTarget.hasEquivalentDoc, true);
 });
 
 test('collects available docs paths from Docusaurus docs data', () => {

--- a/tests/user-related-env-paths.test.cjs
+++ b/tests/user-related-env-paths.test.cjs
@@ -25,9 +25,25 @@ test('detects production and pre-live user-related docs routes', () => {
     getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive/get-user-profile'),
     'pre-live',
   );
+  assert.equal(
+    getUserRelatedDocsEnvironment('/docs/user_related_apis_versioned/get-user-profile/'),
+    'production',
+  );
+  assert.equal(
+    getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive/get-user-profile/'),
+    'pre-live',
+  );
   assert.equal(getUserRelatedDocsEnvironment('/docs/category/user-related-apis'), 'production');
   assert.equal(
+    getUserRelatedDocsEnvironment('/docs/category/user-related-apis/'),
+    'production',
+  );
+  assert.equal(
     getUserRelatedDocsEnvironment('/docs/category/user-related-apis-pre-live'),
+    'pre-live',
+  );
+  assert.equal(
+    getUserRelatedDocsEnvironment('/docs/category/user-related-apis-pre-live/'),
     'pre-live',
   );
   assert.equal(getUserRelatedDocsEnvironment('/docs/category/content-apis'), null);
@@ -57,6 +73,20 @@ test('maps the current doc route between production and pre-live trees', () => {
   );
   assert.equal(
     getUserRelatedDocsPath(
+      '/docs/user_related_apis_prelive/get-user-profile/',
+      'production',
+    ),
+    '/docs/user_related_apis_versioned/get-user-profile',
+  );
+  assert.equal(
+    getUserRelatedDocsPath(
+      '/docs/user_related_apis_versioned/1.0.0/get-user-profile/',
+      'pre-live',
+    ),
+    '/docs/user_related_apis_prelive/get-user-profile',
+  );
+  assert.equal(
+    getUserRelatedDocsPath(
       '/docs/user_related_apis_versioned/get-user-profile',
       'production',
     ),
@@ -71,6 +101,10 @@ test('maps the current doc route between production and pre-live trees', () => {
   );
   assert.equal(
     getUserRelatedDocsPath('/docs/category/user-related-apis', 'pre-live'),
+    '/docs/category/user-related-apis-pre-live',
+  );
+  assert.equal(
+    getUserRelatedDocsPath('/docs/category/user-related-apis/', 'pre-live'),
     '/docs/category/user-related-apis-pre-live',
   );
   assert.equal(
@@ -128,6 +162,14 @@ test('falls back to the environment category when the target doc does not exist'
   );
   assert.equal(versionedProdToPreliveTarget.path, '/docs/user_related_apis_prelive/get-user-profile');
   assert.equal(versionedProdToPreliveTarget.hasEquivalentDoc, true);
+
+  const trailingSlashTarget = getUserRelatedDocsTarget(
+    '/docs/user_related_apis_prelive/get-user-profile/',
+    'production',
+    { availablePaths },
+  );
+  assert.equal(trailingSlashTarget.path, '/docs/user_related_apis_versioned/get-user-profile');
+  assert.equal(trailingSlashTarget.hasEquivalentDoc, true);
 });
 
 test('collects available docs paths from Docusaurus docs data', () => {
@@ -137,7 +179,7 @@ test('collects available docs paths from Docusaurus docs data', () => {
         {
           docs: [
             { path: '/docs/user_related_apis_versioned/get-user-profile' },
-            { path: '/docs/user_related_apis_prelive/get-sync-mutations' },
+            { path: '/docs/user_related_apis_prelive/get-sync-mutations/' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- Normalize user-related API docs paths before environment detection and equivalent-page checks.
- Add regression coverage for Docusaurus trailing slash routes.

## Root Cause
Docusaurus serves docs with trailing slashes while the docs metadata used by the switcher stores paths without them. The environment toggle compared those strings directly, so equivalent pages could be treated as missing.

## Validation
- `node --test tests\user-related-env-paths.test.cjs`
- `yarn test`