### PR TITLE
[codex] Fix Search Console stale URL redirects

### DIFF
--- a/scripts/audit-search-console-coverage.js
+++ b/scripts/audit-search-console-coverage.js
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+
+const { shouldDropSitemapPath } = require("./postbuild-seo.js");
+
+const siteDir = path.resolve(__dirname, "..");
+const buildDir = path.join(siteDir, "build");
+const redirectsPath = path.join(buildDir, "_redirects");
+const sitemapPath = path.join(buildDir, "sitemap.xml");
+const siteOrigin = "https://api-docs.quran.foundation";
+const siteHost = new URL(siteOrigin).host;
+
+function decodeXml(value) {
+  return String(value || "")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function getAttr(attrs, name) {
+  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`, "i"));
+  return match ? decodeXml(match[1]) : null;
+}
+
+function findEndOfCentralDirectory(buffer) {
+  for (let offset = buffer.length - 22; offset >= 0; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === 0x06054b50) {
+      return {
+        entries: buffer.readUInt16LE(offset + 10),
+        centralDirectoryOffset: buffer.readUInt32LE(offset + 16),
+      };
+    }
+  }
+
+  throw new Error("Could not find XLSX central directory");
+}
+
+function readZipEntries(filePath) {
+  const buffer = fs.readFileSync(filePath);
+  const eocd = findEndOfCentralDirectory(buffer);
+  const entries = new Map();
+  let offset = eocd.centralDirectoryOffset;
+
+  for (let index = 0; index < eocd.entries; index += 1) {
+    if (buffer.readUInt32LE(offset) !== 0x02014b50) {
+      throw new Error(`Invalid ZIP central directory in ${filePath}`);
+    }
+
+    const method = buffer.readUInt16LE(offset + 10);
+    const compressedSize = buffer.readUInt32LE(offset + 20);
+    const fileNameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+    const name = buffer.toString("utf8", offset + 46, offset + 46 + fileNameLength);
+
+    if (buffer.readUInt32LE(localHeaderOffset) !== 0x04034b50) {
+      throw new Error(`Invalid ZIP local header for ${name}`);
+    }
+
+    const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+    const compressed = buffer.subarray(dataStart, dataStart + compressedSize);
+    const data =
+      method === 0
+        ? compressed
+        : method === 8
+          ? zlib.inflateRawSync(compressed)
+          : null;
+
+    if (!data) {
+      throw new Error(`Unsupported ZIP compression method ${method} for ${name}`);
+    }
+
+    entries.set(name, data.toString("utf8"));
+    offset += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  return entries;
+}
+
+function readSharedStrings(entries) {
+  const xml = entries.get("xl/sharedStrings.xml");
+  if (!xml) {
+    return [];
+  }
+
+  return [...xml.matchAll(/<si\b[^>]*>([\s\S]*?)<\/si>/g)].map(([, si]) =>
+    decodeXml(
+      [...si.matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)]
+        .map(([, text]) => text)
+        .join(""),
+    ),
+  );
+}
+
+function getWorkbookSheetPath(entries, sheetName) {
+  const workbook = entries.get("xl/workbook.xml");
+  const rels = entries.get("xl/_rels/workbook.xml.rels");
+  if (!workbook || !rels) {
+    throw new Error("XLSX workbook metadata is missing");
+  }
+
+  const sheet = [...workbook.matchAll(/<sheet\b([^>]*)\/>/g)]
+    .map(([, attrs]) => ({
+      name: getAttr(attrs, "name"),
+      relId: getAttr(attrs, "r:id"),
+    }))
+    .find((item) => item.name === sheetName);
+
+  if (!sheet) {
+    throw new Error(`XLSX sheet not found: ${sheetName}`);
+  }
+
+  const rel = [...rels.matchAll(/<Relationship\b([^>]*)\/>/g)]
+    .map(([, attrs]) => ({
+      id: getAttr(attrs, "Id"),
+      target: getAttr(attrs, "Target"),
+    }))
+    .find((item) => item.id === sheet.relId);
+
+  if (!rel) {
+    throw new Error(`XLSX sheet relationship not found: ${sheet.relId}`);
+  }
+
+  return `xl/${rel.target.replace(/^\//, "")}`;
+}
+
+function columnIndex(cellRef) {
+  const letters = String(cellRef || "A").match(/^[A-Z]+/i)?.[0] || "A";
+  return [...letters.toUpperCase()].reduce(
+    (value, letter) => value * 26 + letter.charCodeAt(0) - 64,
+    0,
+  ) - 1;
+}
+
+function readWorksheetRows(entries, sheetName) {
+  const sharedStrings = readSharedStrings(entries);
+  const sheetPath = getWorkbookSheetPath(entries, sheetName);
+  const xml = entries.get(sheetPath);
+  if (!xml) {
+    throw new Error(`XLSX worksheet payload missing: ${sheetPath}`);
+  }
+
+  return [...xml.matchAll(/<row\b[^>]*>([\s\S]*?)<\/row>/g)].map(([, rowXml]) => {
+    const row = [];
+
+    for (const [, attrs, cellXml] of rowXml.matchAll(/<c\b([^>]*)>([\s\S]*?)<\/c>/g)) {
+      const index = columnIndex(getAttr(attrs, "r"));
+      const type = getAttr(attrs, "t");
+      const value = cellXml.match(/<v>([\s\S]*?)<\/v>/)?.[1] || "";
+
+      if (type === "s") {
+        row[index] = sharedStrings[Number(value)] || "";
+      } else if (type === "inlineStr") {
+        row[index] = decodeXml(
+          [...cellXml.matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)]
+            .map(([, text]) => text)
+            .join(""),
+        );
+      } else {
+        row[index] = decodeXml(value);
+      }
+    }
+
+    return row;
+  });
+}
+
+function readSearchConsoleExport(filePath) {
+  const entries = readZipEntries(filePath);
+  const tableRows = readWorksheetRows(entries, "Table");
+  const metadataRows = readWorksheetRows(entries, "Metadata");
+  const urlIndex = tableRows[0]?.findIndex((value) => value === "URL");
+  const issue =
+    metadataRows.find((row) => row[0] === "Issue")?.[1] ||
+    path.basename(filePath);
+
+  if (urlIndex == null || urlIndex < 0) {
+    throw new Error(`Could not find URL column in ${filePath}`);
+  }
+
+  return {
+    issue,
+    urls: tableRows.slice(1).map((row) => row[urlIndex]).filter(Boolean),
+  };
+}
+
+function readRedirectSources() {
+  if (!fs.existsSync(redirectsPath)) {
+    return new Map();
+  }
+
+  const redirects = new Map();
+  for (const line of fs.readFileSync(redirectsPath, "utf8").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const [source, target, status] = trimmed.split(/\s+/);
+    redirects.set(source, { target, status });
+  }
+
+  return redirects;
+}
+
+function readSitemapPaths() {
+  if (!fs.existsSync(sitemapPath)) {
+    return new Set();
+  }
+
+  const sitemap = fs.readFileSync(sitemapPath, "utf8");
+  return new Set(
+    [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+      ([, rawUrl]) => new URL(rawUrl).pathname,
+    ),
+  );
+}
+
+function buildPathExists(pathname) {
+  const relativePath = pathname.replace(/^\//, "");
+  const candidate = pathname.endsWith("/")
+    ? path.join(buildDir, relativePath, "index.html")
+    : path.extname(pathname)
+      ? path.join(buildDir, relativePath)
+      : path.join(buildDir, relativePath, "index.html");
+
+  return fs.existsSync(candidate);
+}
+
+function pathnameFromUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  if (url.host !== siteHost || !["http:", "https:"].includes(url.protocol)) {
+    throw new Error(`Unexpected Search Console origin: ${rawUrl}`);
+  }
+
+  return url.pathname;
+}
+
+function classify(pathname, issue, redirects, sitemapPaths) {
+  if (redirects.has(pathname)) {
+    return "redirected";
+  }
+
+  if (/\/auth-[a-z0-9-]+\/?$/i.test(pathname)) {
+    return issue === "Not found (404)" ? "unresolved-404" : "manual-review";
+  }
+
+  if (issue === "Not found (404)") {
+    return "unresolved-404";
+  }
+
+  if (shouldDropSitemapPath(pathname)) {
+    return "canonicalized-alternate";
+  }
+
+  if (sitemapPaths.has(pathname)) {
+    return "valid-self-canonical";
+  }
+
+  if (buildPathExists(pathname)) {
+    return "valid-static-resource";
+  }
+
+  return "manual-review";
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    throw new Error("Usage: node scripts/audit-search-console-coverage.js <export.xlsx> [...]");
+  }
+
+  const redirects = readRedirectSources();
+  const sitemapPaths = readSitemapPaths();
+  let unresolvedCount = 0;
+
+  for (const filePath of files) {
+    const { issue, urls } = readSearchConsoleExport(filePath);
+    const counts = new Map();
+    const examples = [];
+
+    for (const rawUrl of urls) {
+      const pathname = pathnameFromUrl(rawUrl);
+      const classification = classify(pathname, issue, redirects, sitemapPaths);
+      counts.set(classification, (counts.get(classification) || 0) + 1);
+      if (
+        (classification === "unresolved-404" || classification === "manual-review") &&
+        examples.length < 8
+      ) {
+        examples.push(pathname);
+      }
+    }
+
+    unresolvedCount += counts.get("unresolved-404") || 0;
+
+    console.log(
+      JSON.stringify(
+        {
+          file: path.basename(filePath),
+          issue,
+          total: urls.length,
+          counts: Object.fromEntries([...counts.entries()].sort()),
+          examples,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  if (unresolvedCount > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/postbuild-seo.js
+++ b/scripts/postbuild-seo.js
@@ -353,13 +353,22 @@ function getCanonicalRedirectTarget(target) {
 function parseRedirects(content) {
   const redirects = new Map();
 
-  for (const line of content.split(/\r?\n/)) {
+  for (const [index, line] of content.split(/\r?\n/).entries()) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) {
       continue;
     }
 
-    const [source, target, status = "302"] = trimmed.split(/\s+/);
+    const tokens = trimmed.split(/\s+/);
+    if (tokens.length < 2 || tokens.length > 3) {
+      throw new Error(`Malformed redirect on line ${index + 1}: ${line}`);
+    }
+
+    const [source, target, status = "301"] = tokens;
+    if (redirects.has(source)) {
+      throw new Error(`Duplicate redirect source on line ${index + 1}: ${source}`);
+    }
+
     redirects.set(source, { target, status });
   }
 
@@ -368,7 +377,7 @@ function parseRedirects(content) {
 
 function stripGeneratedRedirectsSection(content) {
   const sectionPattern = new RegExp(
-    `\\n?${generatedRedirectsStart}[\\s\\S]*?${generatedRedirectsEnd}\\n?`,
+    `(?:\\r?\\n)?${generatedRedirectsStart}[\\s\\S]*?${generatedRedirectsEnd}(?:\\r?\\n)?`,
     "g",
   );
 
@@ -766,5 +775,6 @@ module.exports = {
   normalizeSiteUrl,
   operationIdToGeneratedSlug,
   shouldDropSitemapPath,
+  stripGeneratedRedirectsSection,
   validateNoRedirectLoops,
 };

--- a/scripts/postbuild-seo.js
+++ b/scripts/postbuild-seo.js
@@ -6,13 +6,34 @@ const path = require("path");
 const BUILD_DIR = path.join(__dirname, "..", "build");
 const DOCS_DIR = path.join(__dirname, "..", "docs");
 const SITEMAP_PATH = path.join(BUILD_DIR, "sitemap.xml");
+const REDIRECTS_PATH = path.join(BUILD_DIR, "_redirects");
+const GENERATED_AUTH_REDIRECTS_PATH = path.join(
+  __dirname,
+  "..",
+  ".docusaurus",
+  "generated-auth-api-redirects.json",
+);
+const SEARCH_CONSOLE_REDIRECT_OVERRIDES_PATH = path.join(
+  __dirname,
+  "search-console-redirect-overrides.json",
+);
 const SITE_ORIGIN = "https://api-docs.quran.foundation";
+const SITE_HOST = new URL(SITE_ORIGIN).host;
+const STATIC_REDIRECT_LIMIT = 2000;
+const DYNAMIC_REDIRECT_LIMIT = 100;
+const generatedRedirectsStart = "# BEGIN generated-search-console-redirects";
+const generatedRedirectsEnd = "# END generated-search-console-redirects";
 const versionedApiFamilies = [
   "content_apis_versioned",
   "oauth2_apis_versioned",
   "search_apis_versioned",
   "user_related_apis_versioned",
 ];
+const docsDirsWithAuthAliases = [
+  "user_related_apis_prelive",
+  "user_related_apis_versioned",
+];
+const generatedApiDocPattern = /\.(api|info|tag)\.mdx$/;
 const categoryAliasTargets = {
   "content-apis": "content_apis_versioned",
   oauth2_apis: "oauth2_apis_versioned",
@@ -39,6 +60,10 @@ function normalizePathname(pathname) {
   }
 
   return pathname;
+}
+
+function stripTrailingSlash(pathname) {
+  return pathname !== "/" ? pathname.replace(/\/$/, "") : pathname;
 }
 
 function readJsonFile(filePath) {
@@ -153,6 +178,28 @@ function shouldDropSitemapPath(pathname) {
   return true;
 }
 
+function walkFiles(dir, predicate = () => true) {
+  const files = [];
+
+  if (!fs.existsSync(dir)) {
+    return files;
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, predicate));
+      continue;
+    }
+
+    if (entry.isFile() && predicate(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
 function getBuiltHtmlPathname(htmlPath) {
   const relativePath = path.relative(BUILD_DIR, htmlPath).split(path.sep).join("/");
 
@@ -168,23 +215,7 @@ function getBuiltHtmlPathname(htmlPath) {
 }
 
 function rewriteHtmlCanonicals() {
-  const htmlFiles = [];
-
-  function walk(dir) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(fullPath);
-        continue;
-      }
-
-      if (entry.isFile() && entry.name.endsWith(".html")) {
-        htmlFiles.push(fullPath);
-      }
-    }
-  }
-
-  walk(BUILD_DIR);
+  const htmlFiles = walkFiles(BUILD_DIR, (filePath) => filePath.endsWith(".html"));
 
   const linkPattern =
     /(<link[^>]+rel="(?:canonical|alternate)"[^>]+href=")(https:\/\/api-docs\.quran\.foundation[^"]*)(")/g;
@@ -244,6 +275,474 @@ function rewriteSitemap() {
   fs.writeFileSync(SITEMAP_PATH, rewritten);
 }
 
+function normalizeRedirectPath(value) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) {
+    throw new Error("Redirect path cannot be empty");
+  }
+
+  const url = rawValue.startsWith("http://") || rawValue.startsWith("https://")
+    ? new URL(rawValue)
+    : null;
+
+  if (url && url.host !== SITE_HOST) {
+    throw new Error(`Only same-host redirects are supported: ${rawValue}`);
+  }
+
+  if (url?.search || url?.hash) {
+    throw new Error(`Redirect path must not include query strings or hashes: ${rawValue}`);
+  }
+
+  const pathname = url ? url.pathname : rawValue;
+  if (!pathname.startsWith("/")) {
+    throw new Error(`Redirect path must start with /: ${rawValue}`);
+  }
+
+  if (pathname.includes("?") || pathname.includes("#")) {
+    throw new Error(`Redirect path must not include query strings or hashes: ${rawValue}`);
+  }
+
+  return pathname;
+}
+
+function getRedirectSourceVariants(source) {
+  const pathname = normalizeRedirectPath(source);
+
+  if (pathname === "/" || isStaticAsset(pathname)) {
+    return [pathname];
+  }
+
+  const withoutSlash = stripTrailingSlash(pathname);
+  const withSlash = normalizePathname(withoutSlash);
+
+  return withoutSlash === withSlash ? [withoutSlash] : [withoutSlash, withSlash];
+}
+
+function docsRouteSourceExists(routePath) {
+  const pathname = normalizeRedirectPath(routePath);
+  const docId = pathname
+    .replace(/^\/docs\//, "")
+    .replace(/\/$/, "");
+  const sourcePath = path.join(DOCS_DIR, ...docId.split("/"));
+  return [".api.mdx", ".info.mdx", ".tag.mdx", ".mdx", ".md"].some((extension) =>
+    fs.existsSync(`${sourcePath}${extension}`),
+  );
+}
+
+function getCanonicalRedirectTarget(target) {
+  const pathname = normalizePathname(normalizeRedirectPath(target));
+  const match = pathname.match(/^\/docs\/([^/]+)\/([^/]+)\/$/);
+  if (!match) {
+    return pathname;
+  }
+
+  const [, family, slug] = match;
+  const currentVersion = versionedApiRoots[family];
+  if (!currentVersion || slug === currentVersion) {
+    return pathname;
+  }
+
+  if (family === "user_related_apis_versioned" && slug === "scopes") {
+    return pathname;
+  }
+
+  const versionedTarget = `/docs/${family}/${currentVersion}/${slug}/`;
+  return docsRouteSourceExists(versionedTarget) ? versionedTarget : pathname;
+}
+
+function parseRedirects(content) {
+  const redirects = new Map();
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const [source, target, status = "302"] = trimmed.split(/\s+/);
+    redirects.set(source, { target, status });
+  }
+
+  return redirects;
+}
+
+function stripGeneratedRedirectsSection(content) {
+  const sectionPattern = new RegExp(
+    `\\n?${generatedRedirectsStart}[\\s\\S]*?${generatedRedirectsEnd}\\n?`,
+    "g",
+  );
+
+  return content.replace(sectionPattern, "\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
+function createRedirectRegistry(existingContent = "") {
+  const existingRedirects = parseRedirects(existingContent);
+  const redirects = new Map(existingRedirects);
+  const generated = new Map();
+
+  function addRedirect(source, target, options = {}) {
+    const {
+      includeSourceVariants = true,
+      skipExisting = false,
+      status = "301",
+    } = options;
+    const normalizedTarget = getCanonicalRedirectTarget(target);
+    const sources = includeSourceVariants
+      ? getRedirectSourceVariants(source)
+      : [normalizeRedirectPath(source)];
+
+    for (const sourceVariant of sources) {
+      if (sourceVariant === normalizedTarget) {
+        continue;
+      }
+
+      const existing = redirects.get(sourceVariant);
+      if (existing) {
+        if (existing.target === normalizedTarget && existing.status === status) {
+          continue;
+        }
+
+        if (skipExisting) {
+          continue;
+        }
+
+        throw new Error(
+          `Conflicting redirect for ${sourceVariant}: ${existing.target} ${existing.status} vs ${normalizedTarget} ${status}`,
+        );
+      }
+
+      redirects.set(sourceVariant, { target: normalizedTarget, status });
+      generated.set(sourceVariant, { target: normalizedTarget, status });
+    }
+  }
+
+  return {
+    addRedirect,
+    generated,
+    redirects,
+  };
+}
+
+function getDocId(filePath) {
+  return path
+    .relative(path.join(__dirname, ".."), filePath)
+    .split(path.sep)
+    .join("/")
+    .replace(/^docs\//, "")
+    .replace(/\.(api|info|tag)\.mdx$/, "");
+}
+
+function docIdToDocsPath(docId) {
+  return `/docs/${docId}/`;
+}
+
+function getDocRoutePath(filePath) {
+  return docIdToDocsPath(getDocId(filePath));
+}
+
+function getFrontMatterValue(content, key) {
+  const frontMatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontMatterMatch) {
+    return null;
+  }
+
+  const lineMatch = frontMatterMatch[1].match(
+    new RegExp(`^${key}:\\s*(?:"([^"]+)"|'([^']+)'|(.+))\\s*$`, "m"),
+  );
+
+  if (!lineMatch) {
+    return null;
+  }
+
+  return lineMatch[1] || lineMatch[2] || lineMatch[3].trim();
+}
+
+function getApiFrontMatter(content) {
+  const apiValue = getFrontMatterValue(content, "api");
+  if (!apiValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(apiValue);
+  } catch (error) {
+    throw new Error(`Failed to parse api front matter: ${error.message}`);
+  }
+}
+
+function operationIdToGeneratedSlug(operationId) {
+  return String(operationId)
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/([A-Za-z])([0-9])/g, "$1-$2")
+    .replace(/([0-9])([A-Za-z])/g, "$1-$2")
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .toLowerCase()
+    .replace(/^-+|-+$/g, "");
+}
+
+function getGeneratedAuthRedirectsFromDoc(filePath, content) {
+  const api = getApiFrontMatter(content);
+  const operationId = api?.operationId;
+
+  if (!operationId || !String(operationId).startsWith("auth")) {
+    return [];
+  }
+
+  const generatedSlug = operationIdToGeneratedSlug(operationId);
+  if (!generatedSlug.startsWith("auth-")) {
+    return [];
+  }
+
+  const target = getDocRoutePath(filePath);
+  const docId = getDocId(filePath);
+  const currentSlug = docId.split("/").pop();
+  if (generatedSlug === currentSlug) {
+    return [];
+  }
+
+  const sourceDocId = [...docId.split("/").slice(0, -1), generatedSlug].join("/");
+  const source = docIdToDocsPath(sourceDocId);
+
+  return [
+    { source: stripTrailingSlash(source), target },
+    { source, target },
+  ];
+}
+
+function collectGeneratedAuthRedirectsFromDocs() {
+  const redirects = [];
+
+  for (const docsDir of docsDirsWithAuthAliases) {
+    const fullDocsDir = path.join(DOCS_DIR, docsDir);
+    const files = walkFiles(fullDocsDir, (filePath) =>
+      generatedApiDocPattern.test(filePath),
+    );
+
+    for (const filePath of files) {
+      redirects.push(
+        ...getGeneratedAuthRedirectsFromDoc(
+          filePath,
+          fs.readFileSync(filePath, "utf8"),
+        ),
+      );
+    }
+  }
+
+  return redirects;
+}
+
+function readGeneratedAuthRedirectManifest() {
+  if (!fs.existsSync(GENERATED_AUTH_REDIRECTS_PATH)) {
+    return [];
+  }
+
+  const manifest = readJsonFile(GENERATED_AUTH_REDIRECTS_PATH);
+  const redirects = Array.isArray(manifest) ? manifest : manifest.redirects;
+  if (!Array.isArray(redirects)) {
+    throw new Error(`Invalid generated redirect manifest: ${GENERATED_AUTH_REDIRECTS_PATH}`);
+  }
+
+  return redirects;
+}
+
+function readSearchConsoleRedirectOverrides() {
+  if (!fs.existsSync(SEARCH_CONSOLE_REDIRECT_OVERRIDES_PATH)) {
+    return [];
+  }
+
+  const manifest = readJsonFile(SEARCH_CONSOLE_REDIRECT_OVERRIDES_PATH);
+  if (!Array.isArray(manifest.redirects)) {
+    throw new Error(
+      `Invalid Search Console redirect override manifest: ${SEARCH_CONSOLE_REDIRECT_OVERRIDES_PATH}`,
+    );
+  }
+
+  return manifest.redirects;
+}
+
+function collectVersionedApiAliasRedirects() {
+  const redirects = [];
+
+  for (const family of versionedApiFamilies) {
+    const currentVersion = versionedApiRoots[family];
+    const versionDir = path.join(DOCS_DIR, family, currentVersion);
+    const files = walkFiles(versionDir, (filePath) => generatedApiDocPattern.test(filePath));
+
+    for (const filePath of files) {
+      const slug = path.basename(filePath).replace(generatedApiDocPattern, "");
+      if (family === "user_related_apis_versioned" && slug === "scopes") {
+        continue;
+      }
+
+      redirects.push({
+        source: `/docs/${family}/${slug}/`,
+        target: `/docs/${family}/${currentVersion}/${slug}/`,
+      });
+    }
+  }
+
+  return redirects;
+}
+
+function collectSlashRedirectsFromBuild() {
+  return walkFiles(BUILD_DIR, (filePath) => filePath.endsWith(".html"))
+    .map((htmlPath) => getBuiltHtmlPathname(htmlPath))
+    .filter((pathname) => pathname !== "/" && pathname !== "/404/" && pathname.endsWith("/"))
+    .map((pathname) => ({
+      source: stripTrailingSlash(pathname),
+      target: pathname,
+    }));
+}
+
+function getBuildPathForTarget(targetPath) {
+  const pathname = normalizeRedirectPath(targetPath);
+  const relativePath = pathname.replace(/^\//, "");
+
+  if (pathname === "/") {
+    return path.join(BUILD_DIR, "index.html");
+  }
+
+  if (pathname.endsWith("/")) {
+    return path.join(BUILD_DIR, relativePath, "index.html");
+  }
+
+  if (isStaticAsset(pathname)) {
+    return path.join(BUILD_DIR, relativePath);
+  }
+
+  return path.join(BUILD_DIR, relativePath, "index.html");
+}
+
+function validateGeneratedRedirectTargets(generatedRedirects) {
+  const missingTargets = [];
+
+  for (const { target } of generatedRedirects.values()) {
+    const targetPath = getBuildPathForTarget(target);
+    if (!fs.existsSync(targetPath)) {
+      missingTargets.push(`${target} -> ${targetPath}`);
+    }
+  }
+
+  if (missingTargets.length > 0) {
+    throw new Error(
+      `Generated redirects point at missing build targets:\n${missingTargets
+        .slice(0, 20)
+        .join("\n")}`,
+    );
+  }
+}
+
+function validateRedirectLimits(redirects) {
+  let staticRedirects = 0;
+  let dynamicRedirects = 0;
+
+  for (const [source] of redirects) {
+    if (source.includes(":") || source.includes("*")) {
+      dynamicRedirects += 1;
+    } else {
+      staticRedirects += 1;
+    }
+  }
+
+  if (staticRedirects > STATIC_REDIRECT_LIMIT || dynamicRedirects > DYNAMIC_REDIRECT_LIMIT) {
+    throw new Error(
+      `Cloudflare Pages redirect limits exceeded: ${staticRedirects}/${STATIC_REDIRECT_LIMIT} static, ${dynamicRedirects}/${DYNAMIC_REDIRECT_LIMIT} dynamic`,
+    );
+  }
+}
+
+function validateNoRedirectLoops(redirects) {
+  for (const [source] of redirects) {
+    const seen = new Set([source]);
+    let current = redirects.get(source)?.target;
+
+    while (current && redirects.has(current)) {
+      if (seen.has(current)) {
+        throw new Error(`Redirect loop detected: ${[...seen, current].join(" -> ")}`);
+      }
+
+      seen.add(current);
+      current = redirects.get(current)?.target;
+    }
+  }
+}
+
+function writeRedirects() {
+  const existingContent = fs.existsSync(REDIRECTS_PATH)
+    ? fs.readFileSync(REDIRECTS_PATH, "utf8")
+    : "# Cloudflare Pages redirects configuration\n";
+  const baseContent = stripGeneratedRedirectsSection(existingContent);
+  const registry = createRedirectRegistry(baseContent);
+
+  const exactRedirectSources = [
+    ...readSearchConsoleRedirectOverrides(),
+    ...readGeneratedAuthRedirectManifest(),
+    ...collectGeneratedAuthRedirectsFromDocs(),
+    ...collectVersionedApiAliasRedirects(),
+  ];
+
+  for (const redirect of exactRedirectSources) {
+    registry.addRedirect(redirect.source, redirect.target);
+  }
+
+  for (const redirect of collectSlashRedirectsFromBuild()) {
+    registry.addRedirect(redirect.source, redirect.target, { skipExisting: true });
+  }
+
+  validateGeneratedRedirectTargets(registry.generated);
+  validateNoRedirectLoops(registry.redirects);
+  validateRedirectLimits(registry.redirects);
+
+  const generatedLines = [...registry.generated.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([source, { target, status }]) => `${source} ${target} ${status}`);
+
+  const generatedSection = [
+    generatedRedirectsStart,
+    "# Generated by scripts/postbuild-seo.js. Do not edit this section by hand.",
+    ...generatedLines,
+    generatedRedirectsEnd,
+  ].join("\n");
+
+  fs.writeFileSync(
+    REDIRECTS_PATH,
+    `${baseContent.trimEnd()}\n\n${generatedSection}\n`,
+    "utf8",
+  );
+}
+
+function assertNoStaleSeoReferences() {
+  const checkedFiles = [
+    SITEMAP_PATH,
+    path.join(BUILD_DIR, "llms.txt"),
+    ...walkFiles(BUILD_DIR, (filePath) => filePath.endsWith(".html")),
+  ].filter((filePath) => fs.existsSync(filePath));
+  const staleReferences = [];
+  const staleAuthPattern = /\/docs\/[^"'<\s)]*\/auth-[a-z0-9-]*/i;
+
+  for (const filePath of checkedFiles) {
+    const content = fs.readFileSync(filePath, "utf8");
+    const match = content.match(staleAuthPattern);
+    if (match) {
+      staleReferences.push(`${path.relative(BUILD_DIR, filePath)}: ${match[0]}`);
+    }
+  }
+
+  const sitemap = fs.readFileSync(SITEMAP_PATH, "utf8");
+  for (const [, rawUrl] of sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const pathname = new URL(rawUrl).pathname;
+    if (shouldDropSitemapPath(pathname)) {
+      staleReferences.push(`sitemap.xml contains dropped alias: ${pathname}`);
+    }
+  }
+
+  if (staleReferences.length > 0) {
+    throw new Error(
+      `Stale SEO references found:\n${staleReferences.slice(0, 20).join("\n")}`,
+    );
+  }
+}
+
 function main() {
   if (!fs.existsSync(BUILD_DIR) || !fs.existsSync(SITEMAP_PATH)) {
     throw new Error("Build output is missing; run the Docusaurus build first.");
@@ -251,6 +750,8 @@ function main() {
 
   rewriteHtmlCanonicals();
   rewriteSitemap();
+  writeRedirects();
+  assertNoStaleSeoReferences();
 }
 
 if (require.main === module) {
@@ -258,7 +759,12 @@ if (require.main === module) {
 }
 
 module.exports = {
+  createRedirectRegistry,
   getCanonicalPathOverride,
+  getGeneratedAuthRedirectsFromDoc,
+  normalizeRedirectPath,
   normalizeSiteUrl,
+  operationIdToGeneratedSlug,
   shouldDropSitemapPath,
+  validateNoRedirectLoops,
 };

--- a/scripts/prune-generated-api-aliases.js
+++ b/scripts/prune-generated-api-aliases.js
@@ -4,6 +4,11 @@ const fs = require("fs");
 const path = require("path");
 
 const siteDir = path.resolve(__dirname, "..");
+const generatedRedirectsPath = path.join(
+  siteDir,
+  ".docusaurus",
+  "generated-auth-api-redirects.json",
+);
 const docsDirs = [
   "docs/user_related_apis_prelive",
   "docs/user_related_apis_versioned",
@@ -81,6 +86,37 @@ function replaceFrontMatterId(content, id) {
   return content.replace(/^id:\s*.*$/m, `id: ${id}`);
 }
 
+function docIdToDocsPath(docId) {
+  return `/docs/${docId}/`;
+}
+
+function createRedirectsForReplacement(oldDocId, newDocId) {
+  const oldPath = docIdToDocsPath(oldDocId);
+  const newPath = docIdToDocsPath(newDocId);
+  const oldPathWithoutSlash = oldPath.replace(/\/$/, "");
+
+  return [
+    { source: oldPathWithoutSlash, target: newPath },
+    { source: oldPath, target: newPath },
+  ];
+}
+
+function writeGeneratedRedirects(redirects) {
+  fs.mkdirSync(path.dirname(generatedRedirectsPath), { recursive: true });
+  fs.writeFileSync(
+    generatedRedirectsPath,
+    `${JSON.stringify(
+      {
+        generatedBy: "scripts/prune-generated-api-aliases.js",
+        redirects,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
 function rewriteSidebarDocIds(replacements) {
   const sidebarFiles = [];
 
@@ -129,46 +165,63 @@ function walkAllFiles(dir) {
   return results;
 }
 
-let normalized = 0;
-const replacements = [];
-const claimedTargetPaths = new Map();
+function main() {
+  let normalized = 0;
+  const replacements = [];
+  const redirects = [];
+  const claimedTargetPaths = new Map();
 
-for (const docsDir of docsDirs) {
-  if (!fs.existsSync(docsDir)) {
-    continue;
-  }
-
-  for (const filePath of walk(docsDir)) {
-    const resolvedPath = path.resolve(filePath);
-
-    if (!resolvedPath.startsWith(docsDir + path.sep)) {
-      throw new Error(`Refusing to delete path outside docs dir: ${resolvedPath}`);
+  for (const docsDir of docsDirs) {
+    if (!fs.existsSync(docsDir)) {
+      continue;
     }
 
-    const content = fs.readFileSync(resolvedPath, "utf8");
-    const legacySlug = getLegacySlug(content);
-    const targetPath = path.join(path.dirname(resolvedPath), `${legacySlug}.api.mdx`);
-    const normalizedContent = replaceFrontMatterId(content, legacySlug);
-    const oldDocId = getDocId(resolvedPath);
-    const newDocId = getDocId(targetPath);
-    const normalizedTargetPath = path.resolve(targetPath);
-    const claimedBy = claimedTargetPaths.get(normalizedTargetPath);
+    for (const filePath of walk(docsDir)) {
+      const resolvedPath = path.resolve(filePath);
 
-    if (claimedBy) {
-      throw new Error(
-        `Generated auth API docs collide on ${normalizedTargetPath}: ${claimedBy} and ${resolvedPath}`,
-      );
+      if (!resolvedPath.startsWith(docsDir + path.sep)) {
+        throw new Error(`Refusing to delete path outside docs dir: ${resolvedPath}`);
+      }
+
+      const content = fs.readFileSync(resolvedPath, "utf8");
+      const legacySlug = getLegacySlug(content);
+      const targetPath = path.join(path.dirname(resolvedPath), `${legacySlug}.api.mdx`);
+      const normalizedContent = replaceFrontMatterId(content, legacySlug);
+      const oldDocId = getDocId(resolvedPath);
+      const newDocId = getDocId(targetPath);
+      const normalizedTargetPath = path.resolve(targetPath);
+      const claimedBy = claimedTargetPaths.get(normalizedTargetPath);
+
+      if (claimedBy) {
+        throw new Error(
+          `Generated auth API docs collide on ${normalizedTargetPath}: ${claimedBy} and ${resolvedPath}`,
+        );
+      }
+
+      claimedTargetPaths.set(normalizedTargetPath, resolvedPath);
+
+      fs.writeFileSync(targetPath, normalizedContent, "utf8");
+      fs.unlinkSync(resolvedPath);
+      replacements.push([oldDocId, newDocId]);
+      redirects.push(...createRedirectsForReplacement(oldDocId, newDocId));
+      normalized += 1;
     }
-
-    claimedTargetPaths.set(normalizedTargetPath, resolvedPath);
-
-    fs.writeFileSync(targetPath, normalizedContent, "utf8");
-    fs.unlinkSync(resolvedPath);
-    replacements.push([oldDocId, newDocId]);
-    normalized += 1;
   }
+
+  rewriteSidebarDocIds(replacements);
+  writeGeneratedRedirects(redirects);
+
+  console.log(
+    `[api-cleanup] Normalized ${normalized} generated auth API docs and recorded ${redirects.length} redirects`,
+  );
 }
 
-rewriteSidebarDocIds(replacements);
+if (require.main === module) {
+  main();
+}
 
-console.log(`[api-cleanup] Normalized ${normalized} generated auth API docs`);
+module.exports = {
+  createRedirectsForReplacement,
+  getLegacySlug,
+  slugify,
+};

--- a/scripts/search-console-redirect-overrides.json
+++ b/scripts/search-console-redirect-overrides.json
@@ -1,0 +1,324 @@
+{
+  "redirects": [
+    {
+      "source": "/docs/category/mobile-apps",
+      "target": "/docs/tutorials/oidc/mobile-apps/"
+    },
+    {
+      "source": "/docs/content_apis_versioned",
+      "target": "/docs/content_apis_versioned/4.0.0/content-apis/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/4.0.0",
+      "target": "/docs/content_apis_versioned/4.0.0/content-apis/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/4.0.0/juzs",
+      "target": "/docs/content_apis_versioned/4.0.0/list-juzs/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/4.0.0/search",
+      "target": "/docs/search_apis_versioned/1.0.0/search-controller-search/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/info",
+      "target": "/docs/content_apis_versioned/4.0.0/get-chapter-info/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/juzs",
+      "target": "/docs/content_apis_versioned/4.0.0/list-juzs/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/list-rub-el-hizb-recitaiton",
+      "target": "/docs/content_apis_versioned/4.0.0/list-rub-el-hizb-recitation/"
+    },
+    {
+      "source": "/docs/content_apis_versioned/search",
+      "target": "/docs/search_apis_versioned/1.0.0/search-controller-search/"
+    },
+    {
+      "source": "/docs/oauth2_apis_versioned",
+      "target": "/docs/oauth2_apis_versioned/1.0.0/oauth-2-apis/"
+    },
+    {
+      "source": "/docs/oauth2_apis_versioned/1.0.0",
+      "target": "/docs/oauth2_apis_versioned/1.0.0/oauth-2-apis/"
+    },
+    {
+      "source": "/docs/oauth2_apis_versioned/1.0.0/oauth2_apis",
+      "target": "/docs/oauth2_apis_versioned/1.0.0/oauth-2-apis/"
+    },
+    {
+      "source": "/docs/oauth2_apis_versioned/oauth2_apis",
+      "target": "/docs/oauth2_apis_versioned/1.0.0/oauth-2-apis/"
+    },
+    {
+      "source": "/docs/sdk/audio",
+      "target": "/docs/sdk/javascript/audio/"
+    },
+    {
+      "source": "/docs/sdk/chapters",
+      "target": "/docs/sdk/javascript/chapters/"
+    },
+    {
+      "source": "/docs/sdk/juzs",
+      "target": "/docs/sdk/javascript/juzs/"
+    },
+    {
+      "source": "/docs/sdk/migration",
+      "target": "/docs/sdk/javascript/"
+    },
+    {
+      "source": "/docs/sdk/resources",
+      "target": "/docs/sdk/javascript/resources/"
+    },
+    {
+      "source": "/docs/sdk/search",
+      "target": "/docs/sdk/javascript/search/"
+    },
+    {
+      "source": "/docs/sdk/verses",
+      "target": "/docs/sdk/javascript/verses/"
+    },
+    {
+      "source": "/docs/search_apis_versioned",
+      "target": "/docs/search_apis_versioned/1.0.0/quran-foundation-search-api/"
+    },
+    {
+      "source": "/docs/search_apis_versioned/1.0.0",
+      "target": "/docs/search_apis_versioned/1.0.0/quran-foundation-search-api/"
+    },
+    {
+      "source": "/docs/search_apis_versioned/1.0.0/search-apis",
+      "target": "/docs/search_apis_versioned/1.0.0/quran-foundation-search-api/"
+    },
+    {
+      "source": "/docs/search_apis_versioned/search-apis",
+      "target": "/docs/search_apis_versioned/1.0.0/quran-foundation-search-api/"
+    },
+    {
+      "source": "/docs/tutorials/oidc/request-access",
+      "target": "/request-access/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/add-a-comment",
+      "target": "/docs/user_related_apis_versioned/1.0.0/comments-controller-create/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/add-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-create/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/comments-controller-success",
+      "target": "/docs/user_related_apis_versioned/1.0.0/comments-controller-delete-comment/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/delete-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-delete/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-find-one/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-group-settings",
+      "target": "/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-profile-by-id/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-mutations",
+      "target": "/docs/user_related_apis_prelive/get-mutations/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-posts",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-feed/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-posts-comments",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-get-comments/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-user-notifications",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/get-user-profile",
+      "target": "/docs/user_related_apis_versioned/1.0.0/users-controller-profile/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/invite-user-to-group",
+      "target": "/docs/user_related_apis_versioned/1.0.0/rooms-controller-invite-user-to-room/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/log-a-post-view",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-view-tracking/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/posts-controller-legacy-feed-endpoint",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-feed/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/register-android-device",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/scopes",
+      "target": "/docs/user_related_apis_versioned/scopes/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/send-account-confirmation-email",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/send-reset-password-email",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/toggle-following-a-user",
+      "target": "/docs/user_related_apis_versioned/1.0.0/users-controller-toggle-follow/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/toggle-like-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-toggle-like/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/update-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-edit/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/1.0.0/update-user-notification-settings",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/add-a-comment",
+      "target": "/docs/user_related_apis_versioned/1.0.0/comments-controller-create/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/add-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-create/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/comments-controller-success",
+      "target": "/docs/user_related_apis_versioned/1.0.0/comments-controller-delete-comment/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/delete-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-delete/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-find-one/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-group-settings",
+      "target": "/docs/user_related_apis_versioned/1.0.0/rooms-controller-get-room-profile-by-id/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-mutations",
+      "target": "/docs/user_related_apis_prelive/get-mutations/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-posts",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-feed/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-posts-comments",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-get-comments/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-user-notifications",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/get-user-profile",
+      "target": "/docs/user_related_apis_versioned/1.0.0/users-controller-profile/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/invite-user-to-group",
+      "target": "/docs/user_related_apis_versioned/1.0.0/rooms-controller-invite-user-to-room/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/log-a-post-view",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-view-tracking/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/posts-controller-legacy-feed-endpoint",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-feed/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/register-android-device",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/scopes",
+      "target": "/docs/user_related_apis_versioned/scopes/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/send-account-confirmation-email",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/send-reset-password-email",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/toggle-following-a-user",
+      "target": "/docs/user_related_apis_versioned/1.0.0/users-controller-toggle-follow/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/toggle-like-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-toggle-like/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/update-a-post",
+      "target": "/docs/user_related_apis_versioned/1.0.0/posts-controller-edit/"
+    },
+    {
+      "source": "/docs/user_related_apis_versioned/update-user-notification-settings",
+      "target": "/docs/user_related_apis_versioned/1.0.0/user-related-apis/"
+    },
+    {
+      "source": "/sdk",
+      "target": "/docs/sdk/"
+    },
+    {
+      "source": "/sdk/javascript",
+      "target": "/docs/sdk/javascript/"
+    },
+    {
+      "source": "/sdk/javascript/audio",
+      "target": "/docs/sdk/javascript/audio/"
+    },
+    {
+      "source": "/sdk/javascript/chapters",
+      "target": "/docs/sdk/javascript/chapters/"
+    },
+    {
+      "source": "/sdk/javascript/juzs",
+      "target": "/docs/sdk/javascript/juzs/"
+    },
+    {
+      "source": "/sdk/javascript/migration",
+      "target": "/docs/sdk/javascript/"
+    },
+    {
+      "source": "/sdk/javascript/resources",
+      "target": "/docs/sdk/javascript/resources/"
+    },
+    {
+      "source": "/sdk/javascript/search",
+      "target": "/docs/sdk/javascript/search/"
+    },
+    {
+      "source": "/sdk/javascript/verses",
+      "target": "/docs/sdk/javascript/verses/"
+    }
+  ]
+}

--- a/tests/api-sidebar-cleanup.test.cjs
+++ b/tests/api-sidebar-cleanup.test.cjs
@@ -7,6 +7,9 @@ const {
   normalizeRubElHizbDocLabels,
   normalizeRubElHizbSidebarLabels,
 } = require(path.join(__dirname, '..', 'scripts', 'set-api-displayed-sidebars.js'));
+const {
+  createRedirectsForReplacement,
+} = require(path.join(__dirname, '..', 'scripts', 'prune-generated-api-aliases.js'));
 
 test('drops empty categories that have no surviving items and no link', () => {
   const items = [
@@ -164,4 +167,25 @@ test('normalizes Rub el Hizb alias labels in versioned sidebars', () => {
       ],
     },
   ]);
+});
+
+test('records both slash variants when auth aliases are normalized', () => {
+  assert.deepEqual(
+    createRedirectsForReplacement(
+      'user_related_apis_prelive/auth-post-v-1-reading-sessions',
+      'user_related_apis_prelive/add-or-update-user-reading-session',
+    ),
+    [
+      {
+        source: '/docs/user_related_apis_prelive/auth-post-v-1-reading-sessions',
+        target:
+          '/docs/user_related_apis_prelive/add-or-update-user-reading-session/',
+      },
+      {
+        source: '/docs/user_related_apis_prelive/auth-post-v-1-reading-sessions/',
+        target:
+          '/docs/user_related_apis_prelive/add-or-update-user-reading-session/',
+      },
+    ],
+  );
 });

--- a/tests/postbuild-seo.test.cjs
+++ b/tests/postbuild-seo.test.cjs
@@ -3,9 +3,14 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  createRedirectRegistry,
   getCanonicalPathOverride,
+  getGeneratedAuthRedirectsFromDoc,
+  normalizeRedirectPath,
   normalizeSiteUrl,
+  operationIdToGeneratedSlug,
   shouldDropSitemapPath,
+  validateNoRedirectLoops,
 } = require(path.join(__dirname, '..', 'scripts', 'postbuild-seo.js'));
 
 test('canonicalizes current generated API operation aliases to versioned paths', () => {
@@ -56,5 +61,125 @@ test('normalizes canonical URLs with path overrides', () => {
       '/docs/category/content-apis-4.0.0/',
     ),
     'https://api-docs.quran.foundation/docs/category/content-apis-4.0.0/',
+  );
+});
+
+test('normalizes redirect paths defensively', () => {
+  assert.equal(
+    normalizeRedirectPath('http://api-docs.quran.foundation/docs/sdk'),
+    '/docs/sdk',
+  );
+  assert.throws(
+    () => normalizeRedirectPath('https://api-docs.quran.foundation/docs/sdk?from=gsc'),
+    /query strings or hashes/,
+  );
+  assert.throws(
+    () => normalizeRedirectPath('https://example.com/docs/sdk'),
+    /same-host redirects/,
+  );
+});
+
+test('maps generated auth POST operation aliases to normalized docs routes', () => {
+  const filePath = path.join(
+    __dirname,
+    '..',
+    'docs',
+    'user_related_apis_prelive',
+    'add-or-update-user-reading-session.api.mdx',
+  );
+  const content = `---
+id: add-or-update-user-reading-session
+title: Add or update user reading session
+api: {"operationId":"authPostV1ReadingSessions"}
+---
+`;
+
+  assert.equal(
+    operationIdToGeneratedSlug('authPostV1ReadingSessions'),
+    'auth-post-v-1-reading-sessions',
+  );
+  assert.deepEqual(getGeneratedAuthRedirectsFromDoc(filePath, content), [
+    {
+      source: '/docs/user_related_apis_prelive/auth-post-v-1-reading-sessions',
+      target:
+        '/docs/user_related_apis_prelive/add-or-update-user-reading-session/',
+    },
+    {
+      source: '/docs/user_related_apis_prelive/auth-post-v-1-reading-sessions/',
+      target:
+        '/docs/user_related_apis_prelive/add-or-update-user-reading-session/',
+    },
+  ]);
+});
+
+test('maps generated auth GET operation aliases to normalized docs routes', () => {
+  const filePath = path.join(
+    __dirname,
+    '..',
+    'docs',
+    'user_related_apis_prelive',
+    'get-user-reading-sessions.api.mdx',
+  );
+  const content = `---
+id: get-user-reading-sessions
+title: Get user reading sessions
+api: {"operationId":"authGetV1ReadingSessions"}
+---
+`;
+
+  assert.deepEqual(getGeneratedAuthRedirectsFromDoc(filePath, content), [
+    {
+      source: '/docs/user_related_apis_prelive/auth-get-v-1-reading-sessions',
+      target: '/docs/user_related_apis_prelive/get-user-reading-sessions/',
+    },
+    {
+      source: '/docs/user_related_apis_prelive/auth-get-v-1-reading-sessions/',
+      target: '/docs/user_related_apis_prelive/get-user-reading-sessions/',
+    },
+  ]);
+});
+
+test('generated redirect registry rejects loops', () => {
+  const registry = createRedirectRegistry();
+  registry.addRedirect('/old-page', '/new-page/');
+  registry.addRedirect('/new-page', '/canonical-page/');
+
+  assert.doesNotThrow(() => validateNoRedirectLoops(registry.redirects));
+
+  const loopRegistry = createRedirectRegistry();
+  loopRegistry.addRedirect('/a', '/b/');
+  loopRegistry.addRedirect('/b', '/a/');
+
+  assert.throws(
+    () => validateNoRedirectLoops(loopRegistry.redirects),
+    /Redirect loop detected/,
+  );
+});
+
+test('redirect registry sends unversioned API operation targets to current version', () => {
+  const registry = createRedirectRegistry();
+  registry.addRedirect(
+    '/docs/user_related_apis_versioned/auth-post-v-1-reading-sessions',
+    '/docs/user_related_apis_versioned/add-or-update-user-reading-session/',
+  );
+
+  assert.equal(
+    registry.redirects.get(
+      '/docs/user_related_apis_versioned/auth-post-v-1-reading-sessions',
+    ).target,
+    '/docs/user_related_apis_versioned/1.0.0/add-or-update-user-reading-session/',
+  );
+});
+
+test('redirect registry keeps scopes unversioned', () => {
+  const registry = createRedirectRegistry();
+  registry.addRedirect(
+    '/docs/user_related_apis_versioned/1.0.0/scopes',
+    '/docs/user_related_apis_versioned/scopes/',
+  );
+
+  assert.equal(
+    registry.redirects.get('/docs/user_related_apis_versioned/1.0.0/scopes').target,
+    '/docs/user_related_apis_versioned/scopes/',
   );
 });

--- a/tests/postbuild-seo.test.cjs
+++ b/tests/postbuild-seo.test.cjs
@@ -10,6 +10,7 @@ const {
   normalizeSiteUrl,
   operationIdToGeneratedSlug,
   shouldDropSitemapPath,
+  stripGeneratedRedirectsSection,
   validateNoRedirectLoops,
 } = require(path.join(__dirname, '..', 'scripts', 'postbuild-seo.js'));
 
@@ -153,6 +154,45 @@ test('generated redirect registry rejects loops', () => {
   assert.throws(
     () => validateNoRedirectLoops(loopRegistry.redirects),
     /Redirect loop detected/,
+  );
+});
+
+test('redirect registry rejects malformed and duplicate existing redirects', () => {
+  assert.throws(
+    () => createRedirectRegistry('/old-only\n'),
+    /Malformed redirect/,
+  );
+  assert.throws(
+    () => createRedirectRegistry('/old /new/ 301 extra\n'),
+    /Malformed redirect/,
+  );
+  assert.throws(
+    () => createRedirectRegistry('/old /new/ 301\n/old /other/ 301\n'),
+    /Duplicate redirect source/,
+  );
+});
+
+test('redirect registry defaults two-token existing redirects to 301', () => {
+  const registry = createRedirectRegistry('/old /new/\n');
+
+  assert.deepEqual(registry.redirects.get('/old'), {
+    target: '/new/',
+    status: '301',
+  });
+});
+
+test('strips generated redirects sections with CRLF newlines', () => {
+  assert.equal(
+    stripGeneratedRedirectsSection(
+      [
+        '# Manual',
+        '# BEGIN generated-search-console-redirects',
+        '/old /new/ 301',
+        '# END generated-search-console-redirects',
+        '/kept /target/ 301',
+      ].join('\r\n'),
+    ),
+    '# Manual\n/kept /target/ 301',
   );
 });
 


### PR DESCRIPTION
﻿## Summary

Fixes stale Google/Search Console URLs that were returning 404 after generated `auth-*` OpenAPI docs were normalized to human-readable slugs.

## Root cause

The generation cleanup removed duplicate `auth-*` docs and relied on canonical tags/sitemap pruning, but it did not preserve exact 301 redirects for old URLs that Google had already indexed. A later Cloudflare cleanup also avoided broad dynamic redirect rules because those created loop risk.

## Changes

- Records generated `auth-*` alias redirects during API doc cleanup.
- Writes `build/_redirects` during postbuild by merging generated auth aliases, reviewed Search Console overrides, versioned operation aliases, and slash redirects.
- Keeps redirect rules static/exact and validates target existence, duplicate sources, redirect loops, and Cloudflare Pages limits.
- Keeps `/docs/user_related_apis_versioned/scopes/` unversioned.
- Adds a Search Console export audit script for `.xlsx` coverage drilldowns.
- Adds tests for reading-session aliases, slash variants, versioned targets, scopes, and loop validation.

## Validation

- `yarn test`
- `yarn build`
- `node scripts/audit-search-console-coverage.js <six Search Console exports>`

The local build generated 1,140 static redirects, 0 dynamic redirects, and 0 duplicate sources. All 82 exported `Not found (404)` URLs were classified as redirected.