### PR TITLE
[codex] Hide pre-live sync tutorials from production

### DIFF
--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -3,6 +3,7 @@ id: getting-started
 title: Getting Started with Data Sync
 sidebar_label: Getting Started
 sidebar_position: 1
+draft: true
 ---
 
 # Getting Started with Data Sync

--- a/docs/tutorials/sync/handling-conflicts.mdx
+++ b/docs/tutorials/sync/handling-conflicts.mdx
@@ -3,6 +3,7 @@ id: handling-conflicts
 title: Handling Sync Conflicts
 sidebar_label: Handling Conflicts
 sidebar_position: 2
+draft: true
 ---
 
 # Handling Sync Conflicts

--- a/docs/tutorials/sync/offline-first-patterns.mdx
+++ b/docs/tutorials/sync/offline-first-patterns.mdx
@@ -3,6 +3,7 @@ id: offline-first-patterns
 title: Offline-First Architecture Patterns
 sidebar_label: Offline-First Patterns
 sidebar_position: 3
+draft: true
 ---
 
 # Offline-First Architecture Patterns


### PR DESCRIPTION
## Summary

- Hide the Offline-first Sync tutorial pages from production docs by marking them as Docusaurus drafts.
- Keep the tutorial source in the repo so it can be restored when `/v1/sync` is production-ready.

## Why

The sync tutorial currently reads like production guidance, but `/v1/sync` is only present in the pre-live user API docs/spec. Publishing it in the general production Tutorials nav can send developers toward an API surface that is not ready for production use.

## Validation

- `yarn test`
- `git diff --check`