### PR TITLE
[codex] fix pre-live scopes toggle

### DIFF
--- a/docs/user_related_apis_prelive/scopes.mdx
+++ b/docs/user_related_apis_prelive/scopes.mdx
@@ -5,7 +5,7 @@ displayed_sidebar: user-related-apis-pre-live
 
 # OAuth2 Scopes
 
-Quran.Foundations's OAuth 2.0 scopes provide a way to limit the amount of access that is granted to
+Quran.Foundation's OAuth 2.0 scopes provide a way to limit the amount of access that is granted to
 an access token. When requesting an accessing token, clients should also request the scopes they are
 interested in getting access to. If the APIs are user-related, the user will need to consent to
 granting access to the scopes your app is requesting first.

--- a/docs/user_related_apis_prelive/scopes.mdx
+++ b/docs/user_related_apis_prelive/scopes.mdx
@@ -6,7 +6,7 @@ displayed_sidebar: user-related-apis-pre-live
 # OAuth2 Scopes
 
 Quran.Foundation's OAuth 2.0 scopes provide a way to limit the amount of access that is granted to
-an access token. When requesting an accessing token, clients should also request the scopes they are
+an access token. When requesting an access token, clients should also request the scopes they are
 interested in getting access to. If the APIs are user-related, the user will need to consent to
 granting access to the scopes your app is requesting first.
 

--- a/docs/user_related_apis_prelive/scopes.mdx
+++ b/docs/user_related_apis_prelive/scopes.mdx
@@ -1,0 +1,178 @@
+---
+id: scopes
+displayed_sidebar: user-related-apis-pre-live
+---
+
+# OAuth2 Scopes
+
+Quran.Foundations's OAuth 2.0 scopes provide a way to limit the amount of access that is granted to
+an access token. When requesting an accessing token, clients should also request the scopes they are
+interested in getting access to. If the APIs are user-related, the user will need to consent to
+granting access to the scopes your app is requesting first.
+
+## Standard OAuth2
+
+| Scope          | Description                    |
+| -------------- | ------------------------------ |
+| openid         | OpenID Connect authentication  |
+| offline_access | Allows obtaining refresh tokens |
+
+## Content
+
+| Scope   | Description                                                                      |
+| ------- | -------------------------------------------------------------------------------- |
+| content | Read Quran.Foundation's non user-related content e.g. Tafsirs, Translations, etc |
+
+## Search
+
+| Scope  | Description                               |
+| ------ | ----------------------------------------- |
+| search | Search Quran.Foundation's indexed content |
+
+## Bookmarks
+
+| Scope           | Description                    |
+| --------------- | ------------------------------ |
+| bookmark        | Manage your bookmarks          |
+| bookmark.read   | Read your existing bookmarks   |
+| bookmark.create | Create a new bookmark          |
+| bookmark.delete | Delete your existing bookmarks |
+
+## Collections
+
+| Scope             | Description                           |
+| ----------------- | ------------------------------------- |
+| collection        | Manage your collections list          |
+| collection.read   | Read your existing collections list   |
+| collection.create | Create a new collection               |
+| collection.update | Update your existing collections list |
+| collection.delete | Delete your existing collections list |
+
+## Reading Sessions
+
+| Scope                  | Description                           |
+| ---------------------- | ------------------------------------- |
+| reading_session        | Manage your reading sessions          |
+| reading_session.read   | See your latest reading sessions      |
+| reading_session.create | Create a new reading session          |
+| reading_session.update | Update your existing reading sessions |
+
+## Preferences
+
+| Scope             | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| preference        | Manage your reading and audio preferences         |
+| preference.read   | See your current reading and audio preferences    |
+| preference.update | Update your current reading and audio preferences |
+
+## Activity Days
+
+| Scope                 | Description                          |
+| --------------------- | ------------------------------------ |
+| activity_day          | Manage your activity days            |
+| activity_day.read     | See your latest activity days        |
+| activity_day.create   | Create a new activity day            |
+| activity_day.estimate | Estimate your reading speed of Ayahs |
+| activity_day.update   | Update your existing activity days   |
+| activity_day.delete   | Delete your existing activity days   |
+
+## Goals
+
+| Scope         | Description                    |
+| ------------- | ------------------------------ |
+| goal          | Manage your goal               |
+| goal.read     | See your goal                  |
+| goal.estimate | Estimate your goal's week plan |
+| goal.create   | Create a new goal              |
+| goal.update   | Update your existing goal      |
+| goal.delete   | Delete your goal               |
+
+## Streaks
+
+| Scope         | Description        |
+| ------------- | ------------------ |
+| streak        | Manage your streak |
+| streak.read   | See your streak    |
+| streak.update | Update your streak |
+
+## Users
+
+| Scope               | Description                   |
+| ------------------- | ----------------------------- |
+| user                | Manage your user profile data |
+| user.profile.read   | Read your user profile data   |
+| user.profile.update | Update your user profile data |
+| user.rooms.read     | Read your rooms list          |
+| user.search         | Search for users              |
+| user.follow         | Follow/unfollow users         |
+| user.followers.read | Read user's followers list    |
+| user.following.read | Read user's following list    |
+
+## Posts
+
+| Scope       | Description                             |
+| ----------- | --------------------------------------- |
+| post        | Manage your QuranReflect posts          |
+| post.read   | Read your QuranReflect timeline posts   |
+| post.create | Create a new QuranReflect post          |
+| post.update | Update your QuranReflect posts          |
+| post.delete | Delete your QuranReflect posts          |
+| post.save   | Save QuranReflect posts to your profile |
+| post.like   | Like QuranReflect posts                 |
+| post.report | Report QuranReflect posts               |
+| post.log    | Track post views                        |
+| post.export | Export posts (e.g., PDF)                |
+
+## Comments
+
+| Scope          | Description                            |
+| -------------- | -------------------------------------- |
+| comment        | Manage your QuranReflect post comments |
+| comment.read   | Read QuranReflect posts' comments      |
+| comment.create | Create a new QuranReflect post comment |
+| comment.delete | Delete your QuranReflect post comments |
+| comment.like   | Like/unlike comments                   |
+
+## Rooms
+
+| Scope               | Description                         |
+| ------------------- | ----------------------------------- |
+| room                | Manage your QuranReflect rooms      |
+| room.read           | Read room profiles and lists        |
+| room.create         | Create new groups/pages             |
+| room.update         | Update groups/pages                 |
+| room.admin          | Manage room admin access            |
+| room.search         | Search for rooms                    |
+| room.invite         | Invite users, accept/reject invites |
+| room.join           | Join a group                        |
+| room.leave          | Leave a group                       |
+| room.follow         | Follow a page                       |
+| room.unfollow       | Unfollow a page                     |
+| room.members.read   | Read room members list              |
+| room.members.remove | Remove members from room            |
+| room.posts.read     | Read posts in a room                |
+| room.posts.update   | Update post privacy in room         |
+
+## Tags
+
+| Scope    | Description      |
+| -------- | ---------------- |
+| tag      | Access tags      |
+| tag.read | Read/search tags |
+
+## Notes
+
+| Scope        | Description        |
+| ------------ | ------------------ |
+| note         | Manage your notes  |
+| note.read    | Read your notes    |
+| note.create  | Create a new note  |
+| note.update  | Update your notes  |
+| note.delete  | Delete your notes  |
+| note.publish | Publish your notes |
+
+## Sync
+
+| Scope | Description                                  |
+| ----- | -------------------------------------------- |
+| sync  | Access pre-live offline-first sync endpoints |

--- a/docs/user_related_apis_prelive/scopes.mdx
+++ b/docs/user_related_apis_prelive/scopes.mdx
@@ -21,7 +21,7 @@ granting access to the scopes your app is requesting first.
 
 | Scope   | Description                                                                      |
 | ------- | -------------------------------------------------------------------------------- |
-| content | Read Quran.Foundation's non user-related content e.g. Tafsirs, Translations, etc |
+| content | Read Quran.Foundation's non-user-related content e.g. Tafsirs, Translations, etc |
 
 ## Search
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -290,8 +290,42 @@ const buildUserRelatedApisVersionedItems = () =>
     ),
     "user-related-apis/1.0.0/reading-sessions-vs-activity-days",
   );
-const buildUserRelatedApisPreLiveItems = () =>
-  cloneSidebarItems(safeRequire("./docs/user_related_apis_prelive/sidebar.js", []));
+const buildUserRelatedApisPreLiveItems = () => {
+  const items = cloneSidebarItems(
+    safeRequire("./docs/user_related_apis_prelive/sidebar.js", []),
+  );
+  const scopesDoc = makeApiDocSidebarItem(
+    "user_related_apis_prelive/scopes",
+    "OAuth2 Scopes",
+  );
+
+  if (
+    items.some(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        item.type === "doc" &&
+        item.id === scopesDoc.id,
+    )
+  ) {
+    return items;
+  }
+
+  const introIndex = items.findIndex(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      item.type === "doc" &&
+      item.id === "user_related_apis_prelive/user-related-apis",
+  );
+  const insertAt = introIndex >= 0 ? introIndex + 1 : 0;
+
+  return [
+    ...items.slice(0, insertAt),
+    scopesDoc,
+    ...items.slice(insertAt),
+  ];
+};
 
 const buildOAuth2ApisLatestItems = () =>
   cloneSidebarItems(require("./docs/oauth2_apis_versioned/sidebar.js"));

--- a/tests/prelive-docs-config.test.cjs
+++ b/tests/prelive-docs-config.test.cjs
@@ -59,6 +59,15 @@ test('adds pre-live user-related docs to navigation and sidebars', () => {
     (item) => item.type === 'category',
   );
   assert.equal(generatedIndex.link.slug, '/category/user-related-apis-pre-live');
+  assert.ok(
+    generatedIndex.items.some(
+      (item) =>
+        item.type === 'doc' &&
+        item.id === 'user_related_apis_prelive/scopes' &&
+        item.label === 'OAuth2 Scopes',
+    ),
+    'expected pre-live sidebar to link to the pre-live OAuth2 scopes doc',
+  );
 });
 
 test('publishes both production and pre-live user-related raw spec links', () => {

--- a/tests/scopes-page-env.test.cjs
+++ b/tests/scopes-page-env.test.cjs
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (...segments) =>
+  fs.readFileSync(path.join(__dirname, "..", ...segments), "utf-8");
+
+const productionScopes = read(
+  "docs",
+  "user_related_apis_versioned",
+  "scopes.mdx",
+);
+const preliveScopes = read("docs", "user_related_apis_prelive", "scopes.mdx");
+
+test("sync scope is documented only for the pre-live scopes page", () => {
+  assert.doesNotMatch(productionScopes, /\|\s*sync\s*\|/);
+  assert.match(
+    preliveScopes,
+    /\|\s*sync\s*\|\s*Access pre-live offline-first sync endpoints\s*\|/,
+  );
+});

--- a/tests/user-related-env-paths.test.cjs
+++ b/tests/user-related-env-paths.test.cjs
@@ -129,8 +129,10 @@ test('falls back to the environment intro doc when the target doc does not exist
   const availablePaths = new Set([
     '/docs/user_related_apis_versioned/get-user-profile',
     '/docs/user_related_apis_versioned/1.1.0/get-user-profile',
+    '/docs/user_related_apis_versioned/scopes',
     '/docs/user_related_apis_prelive/get-user-profile',
     '/docs/user_related_apis_prelive/get-sync-mutations',
+    '/docs/user_related_apis_prelive/scopes',
   ]);
 
   const noEquivalentTarget = getUserRelatedDocsTarget(
@@ -174,6 +176,14 @@ test('falls back to the environment intro doc when the target doc does not exist
   );
   assert.equal(versionedProdToPreliveTarget.path, '/docs/user_related_apis_prelive/get-user-profile');
   assert.equal(versionedProdToPreliveTarget.hasEquivalentDoc, true);
+
+  const scopesTarget = getUserRelatedDocsTarget(
+    '/docs/user_related_apis_versioned/scopes',
+    'pre-live',
+    { availablePaths },
+  );
+  assert.equal(scopesTarget.path, '/docs/user_related_apis_prelive/scopes');
+  assert.equal(scopesTarget.hasEquivalentDoc, true);
 
   const trailingSlashTarget = getUserRelatedDocsTarget(
     '/docs/user_related_apis_prelive/get-user-profile/',


### PR DESCRIPTION
## Summary
- Add a pre-live OAuth2 scopes page so the scopes environment switcher has a valid pre-live target.
- Link the pre-live scopes page into the pre-live user-related API sidebar.
- Document `sync` only on the pre-live scopes page and add regression coverage for that behavior.

## Root cause
The production scopes page mapped to `/docs/user_related_apis_prelive/scopes`, but that page did not exist, so the environment switcher could not select Pre-live from the scopes page.

## Validation
- `yarn test`
- `npx docusaurus build`
- Browser check against local build: production scopes has no `sync`; Pre-live switch opens `/docs/user_related_apis_prelive/scopes/` and shows `sync`.