### PR TITLE
[codex] Fix breadcrumb structured data

### DIFF
--- a/docs/user_related_apis_prelive/delete-note-by-id.api.mdx
+++ b/docs/user_related_apis_prelive/delete-note-by-id.api.mdx
@@ -9,7 +9,7 @@ api: {"tags":["Notes"],"description":"Delete a note by its ID.","parameters":[{"
 sidebar_class_name: "delete api-method"
 info_path: docs/user_related_apis_prelive/user-related-apis
 custom_edit_url: null
-displayed_sidebar: APIsSidebar
+displayed_sidebar: user-related-apis-pre-live
 ---
 
 import ApiTabs from "@theme/ApiTabs";

--- a/scripts/set-api-displayed-sidebars.js
+++ b/scripts/set-api-displayed-sidebars.js
@@ -72,6 +72,10 @@ function getDisplayedSidebarId(filePath) {
     versionDirPattern.test(segment),
   );
 
+  if (pathSegments.join('/').startsWith('docs/user_related_apis_prelive/')) {
+    return 'user-related-apis-pre-live';
+  }
+
   return isVersionedDoc ? 'APIsVersionedSidebar' : 'APIsSidebar';
 }
 
@@ -321,6 +325,7 @@ if (require.main === module) {
 
 module.exports = {
   filterMissingSidebarItems,
+  getDisplayedSidebarId,
   hasUsableSidebarLink,
   normalizeRubElHizbDocLabels,
   normalizeRubElHizbSidebarLabels,

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,197 @@
+import React, { type ReactNode } from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import {
+  useHomePageRoute,
+  useSidebarBreadcrumbs,
+} from "@docusaurus/theme-common/internal";
+import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import { translate } from "@docusaurus/Translate";
+import IconHome from "@theme/Icon/Home";
+
+import styles from "./styles.module.css";
+
+type BreadcrumbEntry = {
+  href?: string;
+  isHome?: boolean;
+  label: ReactNode;
+  schemaName: string;
+};
+
+type SchemaEntry = BreadcrumbEntry & {
+  displayIndex: number;
+  position: number;
+};
+
+const homeLabel = translate({
+  id: "theme.docs.breadcrumbs.home",
+  message: "Home page",
+  description: "The ARIA label for the home page in the breadcrumbs",
+});
+
+function getSchemaEntries(entries: BreadcrumbEntry[]): SchemaEntry[] {
+  const lastIndex = entries.length - 1;
+  const candidates = entries
+    .map((entry, displayIndex) => ({ ...entry, displayIndex }))
+    .filter((entry) => entry.href || entry.displayIndex === lastIndex);
+
+  if (candidates.length < 2) {
+    return [];
+  }
+
+  return candidates.map((entry, index) => ({
+    ...entry,
+    position: index + 1,
+  }));
+}
+
+function BreadcrumbsItemLink({
+  children,
+  href,
+  isHome,
+  isLast,
+  schemaName,
+  useMicrodata,
+}: {
+  children: ReactNode;
+  href: string | undefined;
+  isHome: boolean;
+  isLast: boolean;
+  schemaName: string;
+  useMicrodata: boolean;
+}): JSX.Element {
+  const className = "breadcrumbs__link";
+
+  if (isLast || !href) {
+    return (
+      <span className={className} {...(useMicrodata && { itemProp: "name" })}>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <Link
+        aria-label={isHome ? schemaName : undefined}
+        className={clsx(className, isHome && styles.breadcrumbsItemLink)}
+        href={href}
+        {...(useMicrodata && { itemProp: "item" })}>
+        {isHome || !useMicrodata ? (
+          children
+        ) : (
+          <span itemProp="name">{children}</span>
+        )}
+      </Link>
+      {isHome && useMicrodata && <meta itemProp="name" content={schemaName} />}
+    </>
+  );
+}
+
+function BreadcrumbsItem({
+  active,
+  children,
+  position,
+  useMicrodata,
+}: {
+  active?: boolean;
+  children: ReactNode;
+  position?: number;
+  useMicrodata: boolean;
+}): JSX.Element {
+  return (
+    <li
+      {...(useMicrodata && {
+        itemScope: true,
+        itemProp: "itemListElement",
+        itemType: "https://schema.org/ListItem",
+      })}
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}>
+      {children}
+      {useMicrodata && <meta itemProp="position" content={String(position)} />}
+    </li>
+  );
+}
+
+function HomeIcon() {
+  return <IconHome className={styles.breadcrumbHomeIcon} />;
+}
+
+export default function DocBreadcrumbs(): JSX.Element | null {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  const homeHref = useBaseUrl("/");
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  const entries: BreadcrumbEntry[] = [
+    ...(homePageRoute
+      ? [
+          {
+            href: homeHref,
+            isHome: true,
+            label: <HomeIcon />,
+            schemaName: homeLabel,
+          },
+        ]
+      : []),
+    ...breadcrumbs.map((item) => ({
+      href: item.href,
+      label: item.label,
+      schemaName: item.label,
+    })),
+  ];
+  const schemaEntries = getSchemaEntries(entries);
+  const useBreadcrumbListMicrodata = schemaEntries.length >= 2;
+
+  return (
+    <nav
+      className={clsx(
+        ThemeClassNames.docs.docBreadcrumbs,
+        styles.breadcrumbsContainer,
+      )}
+      aria-label={translate({
+        id: "theme.docs.breadcrumbs.navAriaLabel",
+        message: "Breadcrumbs",
+        description: "The ARIA label for the breadcrumbs",
+      })}>
+      <ul
+        className="breadcrumbs"
+        {...(useBreadcrumbListMicrodata && {
+          itemScope: true,
+          itemType: "https://schema.org/BreadcrumbList",
+        })}>
+        {entries.map((entry, displayIndex) => {
+          const isLast = displayIndex === entries.length - 1;
+          const schemaEntry = schemaEntries.find(
+            (item) => item.displayIndex === displayIndex,
+          );
+          const useMicrodata =
+            useBreadcrumbListMicrodata && Boolean(schemaEntry);
+
+          return (
+            <BreadcrumbsItem
+              key={displayIndex}
+              active={isLast}
+              position={schemaEntry?.position}
+              useMicrodata={useMicrodata}>
+              <BreadcrumbsItemLink
+                href={entry.href}
+                isHome={Boolean(entry.isHome)}
+                isLast={isLast}
+                schemaName={entry.schemaName}
+                useMicrodata={useMicrodata}>
+                {entry.label}
+              </BreadcrumbsItemLink>
+            </BreadcrumbsItem>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -148,6 +148,12 @@ export default function DocBreadcrumbs(): JSX.Element | null {
   ];
   const schemaEntries = getSchemaEntries(entries);
   const useBreadcrumbListMicrodata = schemaEntries.length >= 2;
+  const schemaEntriesByDisplayIndex = new Map(
+    schemaEntries.map((schemaEntry) => [
+      schemaEntry.displayIndex,
+      schemaEntry,
+    ]),
+  );
 
   return (
     <nav
@@ -168,9 +174,7 @@ export default function DocBreadcrumbs(): JSX.Element | null {
         })}>
         {entries.map((entry, displayIndex) => {
           const isLast = displayIndex === entries.length - 1;
-          const schemaEntry = schemaEntries.find(
-            (item) => item.displayIndex === displayIndex,
-          );
+          const schemaEntry = schemaEntriesByDisplayIndex.get(displayIndex);
           const useMicrodata =
             useBreadcrumbListMicrodata && Boolean(schemaEntry);
 

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -75,7 +75,7 @@ function BreadcrumbsItemLink({
     <>
       <Link
         aria-label={isHome ? schemaName : undefined}
-        className={clsx(className, isHome && styles.breadcrumbsItemLink)}
+        className={className}
         href={href}
         {...(useMicrodata && { itemProp: "item" })}>
         {isHome || !useMicrodata ? (

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,12 @@
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}
+
+.breadcrumbHomeIcon {
+  position: relative;
+  top: 1px;
+  vertical-align: top;
+  height: 1.1rem;
+  width: 1.1rem;
+}

--- a/tests/api-sidebar-cleanup.test.cjs
+++ b/tests/api-sidebar-cleanup.test.cjs
@@ -4,6 +4,7 @@ const path = require('node:path');
 
 const {
   filterMissingSidebarItems,
+  getDisplayedSidebarId,
   normalizeRubElHizbDocLabels,
   normalizeRubElHizbSidebarLabels,
 } = require(path.join(__dirname, '..', 'scripts', 'set-api-displayed-sidebars.js'));
@@ -126,6 +127,50 @@ api: {"postman":{"name":"By Rub el Hizb number"}}
 
 ## By Rub el Hizb number
 `,
+  );
+});
+
+test('uses the dedicated pre-live sidebar for pre-live API docs', () => {
+  assert.equal(
+    getDisplayedSidebarId(
+      path.join(
+        __dirname,
+        '..',
+        'docs',
+        'user_related_apis_prelive',
+        'delete-note-by-id.api.mdx',
+      ),
+    ),
+    'user-related-apis-pre-live',
+  );
+});
+
+test('keeps shared sidebars for latest and versioned generated API docs', () => {
+  assert.equal(
+    getDisplayedSidebarId(
+      path.join(
+        __dirname,
+        '..',
+        'docs',
+        'user_related_apis_versioned',
+        'delete-note-by-id.api.mdx',
+      ),
+    ),
+    'APIsSidebar',
+  );
+
+  assert.equal(
+    getDisplayedSidebarId(
+      path.join(
+        __dirname,
+        '..',
+        'docs',
+        'user_related_apis_versioned',
+        '1.0.0',
+        'delete-note-by-id.api.mdx',
+      ),
+    ),
+    'APIsVersionedSidebar',
   );
 });
 


### PR DESCRIPTION
## Summary

- Override Docusaurus breadcrumbs so Schema.org `BreadcrumbList` microdata is emitted only when valid `itemListElement` entries can be produced.
- Point the reported pre-live API page at the dedicated pre-live sidebar so the built page has a meaningful breadcrumb trail.
- Update the API sidebar normalization helper and tests so future pre-live API regeneration keeps using the pre-live sidebar.

## Root cause

Google saw a `BreadcrumbList` on `docs/user_related_apis_prelive/delete-note-by-id/`, but the page rendered only a home crumb without valid `itemListElement` entries. That made the breadcrumb structured data invalid.

## Validation

- `yarn re-gen`
- discarded unrelated regenerated MDX churn after re-gen, keeping only the affected generated page change
- `npx docusaurus build`
- `yarn postbuild:seo`
- `yarn test`
- inspected `build/docs/user_related_apis_prelive/delete-note-by-id/index.html`: 1 `BreadcrumbList`, 3 `itemListElement`, 3 `ListItem`, 3 `name`, and 3 `position` fields