### PR TITLE
Fix Search Console indexing signals

### DIFF
--- a/scripts/audit-search-console-coverage.js
+++ b/scripts/audit-search-console-coverage.js
@@ -15,6 +15,8 @@ const siteHost = new URL(siteOrigin).host;
 const defaultTimeoutMs = 10000;
 const defaultMaxRedirects = 8;
 const defaultConcurrency = 12;
+const indexedThoughBlockedIssue = "Indexed, though blocked by robots.txt";
+const pageWithRedirectIssue = "Page with redirect";
 
 function decodeXml(value) {
   return String(value || "")
@@ -218,6 +220,146 @@ function isStaticAsset(pathname) {
   return /\.[a-z0-9]+$/i.test(pathname);
 }
 
+function sitemapUrlFor(rawUrl) {
+  const url = new URL(rawUrl);
+  return `${siteOrigin}${url.pathname}`;
+}
+
+function sitemapUrlVariantsFor(rawUrl) {
+  const url = new URL(rawUrl);
+  const pathname = url.pathname;
+
+  if (pathname === "/" || isStaticAsset(pathname)) {
+    return new Set([sitemapUrlFor(rawUrl)]);
+  }
+
+  const withoutSlash = pathname.replace(/\/$/, "");
+  return new Set([
+    `${siteOrigin}${withoutSlash}`,
+    `${siteOrigin}${withoutSlash}/`,
+  ]);
+}
+
+function parseSitemapUrls(xml) {
+  return new Set(
+    [...String(xml || "").matchAll(/<loc>([^<]+)<\/loc>/g)].map(([, rawUrl]) =>
+      decodeXml(rawUrl),
+    ),
+  );
+}
+
+function readLocalSitemapUrls(filePath = path.join(buildDir, "sitemap.xml")) {
+  if (!fs.existsSync(filePath)) {
+    return new Set();
+  }
+
+  return parseSitemapUrls(fs.readFileSync(filePath, "utf8"));
+}
+
+function readLocalRobotsTxt() {
+  const buildRobotsPath = path.join(buildDir, "robots.txt");
+  const staticRobotsPath = path.join(siteDir, "static", "robots.txt");
+  const filePath = fs.existsSync(buildRobotsPath) ? buildRobotsPath : staticRobotsPath;
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
+}
+
+function normalizeRobotsPath(value) {
+  const pathValue = String(value || "").trim();
+  if (!pathValue || pathValue === "/") {
+    return pathValue;
+  }
+
+  return pathValue.replace(/\*.*$/, "");
+}
+
+function getRobotsGroups(robotsTxt) {
+  const groups = [];
+  let currentGroup = null;
+
+  for (const rawLine of String(robotsTxt || "").split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*/, "").trim();
+    if (!line) {
+      continue;
+    }
+
+    const [, field, rawValue = ""] = line.match(/^([^:]+):\s*(.*)$/) || [];
+    if (!field) {
+      continue;
+    }
+
+    const key = field.toLowerCase();
+    const value = rawValue.trim();
+    if (key === "user-agent") {
+      if (!currentGroup || currentGroup.rules.length > 0) {
+        currentGroup = { agents: [], rules: [] };
+        groups.push(currentGroup);
+      }
+      currentGroup.agents.push(value.toLowerCase());
+      continue;
+    }
+
+    if ((key === "allow" || key === "disallow") && currentGroup) {
+      currentGroup.rules.push({ directive: key, path: normalizeRobotsPath(value) });
+    }
+  }
+
+  return groups;
+}
+
+function robotsAgentMatches(agentToken, userAgent) {
+  return agentToken === "*" || userAgent.toLowerCase().includes(agentToken);
+}
+
+function isPathBlockedByRobots(robotsTxt, pathname, userAgent = "Googlebot") {
+  const matchingGroups = getRobotsGroups(robotsTxt).filter((group) =>
+    group.agents.some((agentToken) => robotsAgentMatches(agentToken, userAgent)),
+  );
+  const specificGroups = matchingGroups.filter((group) =>
+    group.agents.some((agentToken) => agentToken !== "*"),
+  );
+  const matchingRules = (specificGroups.length > 0 ? specificGroups : matchingGroups)
+    .flatMap((group) => group.rules)
+    .filter((rule) => rule.path && pathname.startsWith(rule.path));
+
+  if (matchingRules.length === 0) {
+    return false;
+  }
+
+  matchingRules.sort((left, right) => {
+    const lengthDelta = right.path.length - left.path.length;
+    if (lengthDelta !== 0) {
+      return lengthDelta;
+    }
+
+    return left.directive === "allow" ? -1 : 1;
+  });
+
+  return matchingRules[0].directive === "disallow";
+}
+
+function extractHtmlAttr(tag, attrName) {
+  const match = tag.match(new RegExp(`\\b${attrName}=["']([^"']+)["']`, "i"));
+  return match ? decodeXml(match[1]) : "";
+}
+
+function extractCanonicalUrl(html) {
+  const tag = String(html || "").match(/<link\b[^>]*rel=["']canonical["'][^>]*>/i)?.[0] ||
+    String(html || "").match(/<link\b[^>]*href=["'][^"']+["'][^>]*rel=["']canonical["'][^>]*>/i)?.[0];
+  return tag ? extractHtmlAttr(tag, "href") : "";
+}
+
+function extractMetaRobots(html) {
+  const tag = String(html || "").match(/<meta\b[^>]*name=["']robots["'][^>]*>/i)?.[0] ||
+    String(html || "").match(/<meta\b[^>]*content=["'][^"']+["'][^>]*name=["']robots["'][^>]*>/i)?.[0];
+  return tag ? extractHtmlAttr(tag, "content") : "";
+}
+
+function hasNoindexSignal(signals) {
+  return [signals.metaRobots, signals.xRobotsTag]
+    .filter(Boolean)
+    .some((value) => String(value).toLowerCase().includes("noindex"));
+}
+
 function buildPathForPathname(pathname) {
   const relativePath = pathname.replace(/^\//, "");
   if (pathname === "/") {
@@ -269,7 +411,9 @@ function resolveLocalUrl(rawUrl, options = {}) {
   let pathname = pathnameFromUrl(rawUrl);
 
   for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
-    if (pathExists(pathname)) {
+    const redirect = redirects.get(pathname);
+
+    if (!redirect && pathExists(pathname)) {
       return {
         ok: true,
         outcome: chain.length > 0 ? "redirected" : "ok",
@@ -280,7 +424,6 @@ function resolveLocalUrl(rawUrl, options = {}) {
       };
     }
 
-    const redirect = redirects.get(pathname);
     if (!redirect) {
       return {
         ok: false,
@@ -365,6 +508,7 @@ function requestWithMethod(urlString, method, timeoutMs = defaultTimeoutMs) {
         response.resume();
         resolve({
           statusCode: response.statusCode,
+          headers: response.headers,
           location: response.headers.location || null,
         });
       },
@@ -386,6 +530,66 @@ function requestHead(urlString, timeoutMs = defaultTimeoutMs) {
 
 function requestGet(urlString, timeoutMs = defaultTimeoutMs) {
   return requestWithMethod(urlString, "GET", timeoutMs);
+}
+
+function decodeResponseBody(buffer, encoding) {
+  if (encoding === "gzip") {
+    return zlib.gunzipSync(buffer).toString("utf8");
+  }
+
+  if (encoding === "br") {
+    return zlib.brotliDecompressSync(buffer).toString("utf8");
+  }
+
+  if (encoding === "deflate") {
+    return zlib.inflateSync(buffer).toString("utf8");
+  }
+
+  return buffer.toString("utf8");
+}
+
+function requestContent(urlString, timeoutMs = defaultTimeoutMs) {
+  return new Promise((resolve) => {
+    const url = new URL(urlString);
+    const client = url.protocol === "http:" ? http : https;
+    const request = client.request(
+      url,
+      {
+        method: "GET",
+        timeout: timeoutMs,
+        headers: {
+          "Accept-Encoding": "gzip, br, deflate",
+          "User-Agent": "qf-api-docs-search-console-audit/1.0",
+        },
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          try {
+            resolve({
+              body: decodeResponseBody(
+                Buffer.concat(chunks),
+                response.headers["content-encoding"],
+              ),
+              headers: response.headers,
+              statusCode: response.statusCode,
+            });
+          } catch (error) {
+            resolve({ error: error.message || String(error) });
+          }
+        });
+      },
+    );
+
+    request.on("timeout", () => {
+      request.destroy(new Error("Request timed out"));
+    });
+    request.on("error", (error) => {
+      resolve({ error: error.message || String(error) });
+    });
+    request.end();
+  });
 }
 
 async function resolveHttpUrl(rawUrl, options = {}) {
@@ -487,6 +691,188 @@ async function resolveHttpUrl(rawUrl, options = {}) {
   throw new Error("Unreachable HTTP URL resolution state");
 }
 
+function readLocalIndexSignals(finalUrl) {
+  const pathname = new URL(finalUrl).pathname;
+  if (isStaticAsset(pathname)) {
+    return { contentType: "", canonical: "", metaRobots: "", xRobotsTag: "" };
+  }
+
+  const filePath = buildPathForPathname(pathname);
+  if (!fs.existsSync(filePath)) {
+    return { contentType: "", canonical: "", metaRobots: "", xRobotsTag: "" };
+  }
+
+  const html = fs.readFileSync(filePath, "utf8");
+  return {
+    canonical: extractCanonicalUrl(html),
+    contentType: "text/html",
+    metaRobots: extractMetaRobots(html),
+    xRobotsTag: "",
+  };
+}
+
+async function readLiveIndexSignals(finalUrl, options = {}) {
+  const contentRequest = options.requestContent || requestContent;
+  const response = await contentRequest(finalUrl, options.timeoutMs || defaultTimeoutMs);
+  if (response.error) {
+    return { error: response.error };
+  }
+
+  const body = response.body || "";
+  return {
+    canonical: extractCanonicalUrl(body),
+    contentType: response.headers?.["content-type"] || "",
+    metaRobots: extractMetaRobots(body),
+    xRobotsTag: response.headers?.["x-robots-tag"] || "",
+  };
+}
+
+async function readLiveSitemapUrls(options = {}) {
+  const contentRequest = options.requestContent || requestContent;
+  const origin = options.origin || siteOrigin;
+  const response = await contentRequest(`${origin}/sitemap.xml`, options.timeoutMs);
+  if (response.error || response.statusCode !== 200) {
+    return new Set();
+  }
+
+  return parseSitemapUrls(response.body);
+}
+
+async function readLiveRobotsTxt(options = {}) {
+  const contentRequest = options.requestContent || requestContent;
+  const origin = options.origin || siteOrigin;
+  const response = await contentRequest(`${origin}/robots.txt`, options.timeoutMs);
+  if (response.error || response.statusCode !== 200) {
+    return "";
+  }
+
+  return response.body || "";
+}
+
+function shouldExpectSitemapEntry(finalUrl, signals) {
+  const pathname = new URL(finalUrl).pathname;
+  if (isStaticAsset(pathname)) {
+    return false;
+  }
+
+  return !signals.contentType || signals.contentType.includes("text/html");
+}
+
+function failIndexability(result, outcome, diagnostics) {
+  return {
+    ...result,
+    diagnostics,
+    ok: false,
+    outcome,
+  };
+}
+
+async function applySearchConsoleIssueChecks(rawUrl, issue, result, context, options = {}) {
+  if (!result.ok) {
+    return result;
+  }
+
+  const mode = options.mode || "local";
+  const finalUrl = result.finalUrl;
+  const finalPathname = new URL(finalUrl).pathname;
+  const sourceSitemapUrls = sitemapUrlVariantsFor(rawUrl);
+  const finalSitemapUrl = sitemapUrlFor(finalUrl);
+  const readSignals = options.readIndexSignals ||
+    (mode === "live" ? readLiveIndexSignals : readLocalIndexSignals);
+  const signals = isStaticAsset(finalPathname)
+    ? { contentType: "", canonical: "", metaRobots: "", xRobotsTag: "" }
+    : await readSignals(finalUrl, options);
+  const expectSitemapEntry = shouldExpectSitemapEntry(finalUrl, signals);
+  const robotsBlocked = isPathBlockedByRobots(context.robotsTxt, finalPathname);
+  const matchingSourceSitemapUrls = [...sourceSitemapUrls].filter((url) =>
+    context.sitemapUrls.has(url),
+  );
+
+  if (result.outcome === "redirected" && matchingSourceSitemapUrls.length > 0) {
+    return failIndexability(result, "redirect-source-in-sitemap", {
+      sourceSitemapUrls: matchingSourceSitemapUrls,
+    });
+  }
+
+  if (issue === pageWithRedirectIssue && result.outcome !== "redirected") {
+    return failIndexability(result, "expected-redirect", {
+      issue,
+    });
+  }
+
+  if (issue === indexedThoughBlockedIssue) {
+    if (robotsBlocked) {
+      return failIndexability(result, "blocked-by-robots", {
+        finalPathname,
+      });
+    }
+
+    if (!hasNoindexSignal(signals)) {
+      return failIndexability(result, "missing-noindex", {
+        finalUrl,
+      });
+    }
+
+    if (context.sitemapUrls.has(finalSitemapUrl)) {
+      return failIndexability(result, "noindex-url-in-sitemap", {
+        finalSitemapUrl,
+      });
+    }
+
+    return result;
+  }
+
+  if (robotsBlocked) {
+    return failIndexability(result, "blocked-by-robots", {
+      finalPathname,
+    });
+  }
+
+  if (hasNoindexSignal(signals)) {
+    return failIndexability(result, "unexpected-noindex", {
+      finalUrl,
+    });
+  }
+
+  if (expectSitemapEntry && !context.sitemapUrls.has(finalSitemapUrl)) {
+    return failIndexability(result, "final-url-not-in-sitemap", {
+      finalSitemapUrl,
+    });
+  }
+
+  if (expectSitemapEntry) {
+    if (!signals.canonical) {
+      return failIndexability(result, "missing-canonical", {
+        finalUrl,
+      });
+    }
+
+    let canonicalUrl;
+    try {
+      canonicalUrl = new URL(signals.canonical);
+    } catch {
+      return failIndexability(result, "invalid-canonical", {
+        canonical: signals.canonical,
+      });
+    }
+
+    if (canonicalUrl.origin !== siteOrigin) {
+      return failIndexability(result, "canonical-host-mismatch", {
+        canonical: signals.canonical,
+      });
+    }
+
+    if (signals.canonical !== finalSitemapUrl) {
+      return failIndexability(result, "canonical-url-mismatch", {
+        canonical: signals.canonical,
+        expected: finalSitemapUrl,
+      });
+    }
+  }
+
+  return result;
+}
+
 async function mapLimit(items, limit, iteratee) {
   const results = new Array(items.length);
   let nextIndex = 0;
@@ -523,6 +909,7 @@ function formatFailure(rawUrl, result) {
     finalStatus: result.finalStatus,
     finalUrl: result.finalUrl,
     error: result.error,
+    diagnostics: result.diagnostics,
     chain: result.chain,
   };
 }
@@ -532,6 +919,12 @@ async function auditSearchConsoleExports(files, options = {}) {
   const origin = options.origin || siteOrigin;
   const concurrency = options.concurrency || defaultConcurrency;
   const redirects = options.redirects || (mode === "local" ? readRedirectSources() : null);
+  const context = {
+    robotsTxt: options.robotsTxt ||
+      (mode === "live" ? await readLiveRobotsTxt(options) : readLocalRobotsTxt()),
+    sitemapUrls: options.sitemapUrls ||
+      (mode === "live" ? await readLiveSitemapUrls(options) : readLocalSitemapUrls()),
+  };
   const reports = [];
   let failedUrls = 0;
 
@@ -542,7 +935,18 @@ async function auditSearchConsoleExports(files, options = {}) {
       mode === "live"
         ? (rawUrl) => resolveHttpUrl(rawUrl, options)
         : (rawUrl) => resolveLocalUrl(rawUrl, { ...options, redirects });
-    const results = await mapLimit(uniqueUrls, mode === "live" ? concurrency : 1, resolver);
+    const results = await mapLimit(
+      uniqueUrls,
+      mode === "live" ? concurrency : 1,
+      async (rawUrl) =>
+        applySearchConsoleIssueChecks(
+          rawUrl,
+          issue,
+          await resolver(rawUrl),
+          context,
+          options,
+        ),
+    );
     const failures = results
       .map((result, index) => ({ result, rawUrl: uniqueUrls[index] }))
       .filter(({ result }) => !result.ok)
@@ -672,10 +1076,17 @@ module.exports = {
   auditSearchConsoleExports,
   buildPathForPathname,
   buildPathExists,
+  applySearchConsoleIssueChecks,
+  formatFailure,
+  hasNoindexSignal,
+  isPathBlockedByRobots,
   parseArgs,
+  parseSitemapUrls,
   pathnameFromUrl,
   readRedirectSources,
   readSearchConsoleExport,
   resolveHttpUrl,
   resolveLocalUrl,
+  sitemapUrlFor,
+  sitemapUrlVariantsFor,
 };

--- a/scripts/audit-search-console-coverage.js
+++ b/scripts/audit-search-console-coverage.js
@@ -294,7 +294,7 @@ function getRobotsGroups(robotsTxt) {
         currentGroup = { agents: [], rules: [] };
         groups.push(currentGroup);
       }
-      currentGroup.agents.push(value.toLowerCase());
+      currentGroup.agents.push(normalizeRobotsAgentToken(value));
       continue;
     }
 
@@ -306,18 +306,54 @@ function getRobotsGroups(robotsTxt) {
   return groups;
 }
 
+function normalizeRobotsAgentToken(value) {
+  const token = String(value || "").trim().toLowerCase();
+  return token === "*" ? token : token.replace(/\*+$/, "");
+}
+
 function robotsAgentMatches(agentToken, userAgent) {
-  return agentToken === "*" || userAgent.toLowerCase().includes(agentToken);
+  if (agentToken === "*") {
+    return true;
+  }
+
+  const crawlerToken = normalizeRobotsAgentToken(userAgent);
+  return (
+    crawlerToken === agentToken ||
+    crawlerToken.startsWith(`${agentToken}-`) ||
+    crawlerToken.startsWith(`${agentToken}/`)
+  );
+}
+
+function getMatchingRobotsAgentTokens(groups, userAgent) {
+  const matchingTokens = new Set();
+  for (const group of groups) {
+    for (const agentToken of group.agents) {
+      if (robotsAgentMatches(agentToken, userAgent)) {
+        matchingTokens.add(agentToken);
+      }
+    }
+  }
+
+  const specificTokens = [...matchingTokens].filter((agentToken) => agentToken !== "*");
+  if (specificTokens.length === 0) {
+    return matchingTokens.has("*") ? new Set(["*"]) : new Set();
+  }
+
+  const longestSpecificLength = Math.max(
+    ...specificTokens.map((agentToken) => agentToken.length),
+  );
+  return new Set(
+    specificTokens.filter((agentToken) => agentToken.length === longestSpecificLength),
+  );
 }
 
 function isPathBlockedByRobots(robotsTxt, pathname, userAgent = "Googlebot") {
-  const matchingGroups = getRobotsGroups(robotsTxt).filter((group) =>
-    group.agents.some((agentToken) => robotsAgentMatches(agentToken, userAgent)),
-  );
-  const specificGroups = matchingGroups.filter((group) =>
-    group.agents.some((agentToken) => agentToken !== "*"),
-  );
-  const matchingRules = (specificGroups.length > 0 ? specificGroups : matchingGroups)
+  const groups = getRobotsGroups(robotsTxt);
+  const matchingAgentTokens = getMatchingRobotsAgentTokens(groups, userAgent);
+  const matchingRules = groups
+    .filter((group) =>
+      group.agents.some((agentToken) => matchingAgentTokens.has(agentToken)),
+    )
     .flatMap((group) => group.rules)
     .filter((rule) => rule.path && pathname.startsWith(rule.path));
 

--- a/scripts/postbuild-seo.js
+++ b/scripts/postbuild-seo.js
@@ -50,6 +50,7 @@ const dropPathsFromSitemap = new Set([
   "/request-scopes",
   "/request-scopes/",
 ]);
+let searchConsoleRedirectSourcePaths = null;
 
 function isStaticAsset(pathname) {
   return /\.[a-z0-9]+$/i.test(pathname);
@@ -153,6 +154,10 @@ function shouldDropSitemapPath(pathname) {
     return true;
   }
 
+  if (getSearchConsoleRedirectSourcePaths().has(pathname)) {
+    return true;
+  }
+
   if (
     /^\/docs\/category\/(content-apis|oauth2_apis|search-apis|user-related-apis)\/?$/.test(
       pathname,
@@ -177,6 +182,24 @@ function shouldDropSitemapPath(pathname) {
   }
 
   return true;
+}
+
+function getSearchConsoleRedirectSourcePaths() {
+  if (searchConsoleRedirectSourcePaths) {
+    return searchConsoleRedirectSourcePaths;
+  }
+
+  searchConsoleRedirectSourcePaths = new Set();
+  for (const redirect of readSearchConsoleRedirectOverrides()) {
+    const target = getCanonicalRedirectTarget(redirect.target);
+    for (const source of getRedirectSourceVariants(redirect.source)) {
+      if (source !== target) {
+        searchConsoleRedirectSourcePaths.add(source);
+      }
+    }
+  }
+
+  return searchConsoleRedirectSourcePaths;
 }
 
 function walkFiles(dir, predicate = () => true) {
@@ -608,6 +631,13 @@ function collectVersionedApiAliasRedirects() {
   return redirects;
 }
 
+function collectCategoryAliasRedirects() {
+  return Object.entries(categoryAliasTargets).map(([categorySlug, family]) => ({
+    source: `/docs/category/${categorySlug}/`,
+    target: `/docs/category/${categorySlug}-${versionedApiRoots[family]}/`,
+  }));
+}
+
 function collectSlashRedirectsFromBuild() {
   return walkFiles(BUILD_DIR, (filePath) => filePath.endsWith(".html"))
     .map((htmlPath) => getBuiltHtmlPathname(htmlPath))
@@ -736,6 +766,7 @@ function writeRedirects() {
   const generatedRedirectSources = [
     ...readGeneratedAuthRedirectManifest(),
     ...collectGeneratedAuthRedirectsFromDocs(),
+    ...collectCategoryAliasRedirects(),
     ...collectVersionedApiAliasRedirects(),
   ];
 
@@ -819,6 +850,7 @@ if (require.main === module) {
 
 module.exports = {
   createRedirectRegistry,
+  collectCategoryAliasRedirects,
   getCanonicalPathOverride,
   getGeneratedAuthRedirectsFromDoc,
   getRedirectSourceVariants,

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -1,0 +1,14 @@
+import React from "react";
+import Head from "@docusaurus/Head";
+import SearchPage from "@theme-original/SearchPage";
+
+export default function SearchPageWrapper(props) {
+  return (
+    <>
+      <Head>
+        <meta name="robots" content="noindex,follow" />
+      </Head>
+      <SearchPage {...props} />
+    </>
+  );
+}

--- a/static/_headers
+++ b/static/_headers
@@ -82,6 +82,12 @@
   ! Cache-Control
   Cache-Control: public, max-age=86400
 
+/search
+  X-Robots-Tag: noindex, follow
+
+/search/
+  X-Robots-Tag: noindex, follow
+
 /.well-known/http-message-signatures-directory
   Content-Type: application/http-message-signatures-directory+json
   Cache-Control: public, max-age=86400

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -11,14 +11,12 @@ User-agent: Applebot
 User-agent: MistralAI-User
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
-Disallow: /search
 Disallow: /request-scopes
 
 # Allow Gemini grounding/search while signaling a no-training preference.
 User-agent: Google-Extended
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
-Disallow: /search
 Disallow: /request-scopes
 
 # Block documented training-only bots.
@@ -34,7 +32,6 @@ Disallow: /
 User-agent: *
 Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
-Disallow: /search
 Disallow: /request-scopes
 
 Sitemap: https://api-docs.quran.foundation/sitemap.xml

--- a/tests/postbuild-seo.test.cjs
+++ b/tests/postbuild-seo.test.cjs
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  collectCategoryAliasRedirects,
   createRedirectRegistry,
   getCanonicalPathOverride,
   getGeneratedAuthRedirectsFromDoc,
@@ -46,6 +47,20 @@ test('canonicalizes current generated category aliases to versioned category pag
   );
 });
 
+test('generates redirects from current category aliases to versioned category pages', () => {
+  assert.deepEqual(
+    collectCategoryAliasRedirects().filter((redirect) =>
+      redirect.source.includes('/docs/category/content-apis/'),
+    ),
+    [
+      {
+        source: '/docs/category/content-apis/',
+        target: '/docs/category/content-apis-4.0.0/',
+      },
+    ],
+  );
+});
+
 test('drops current generated API and category aliases from the sitemap', () => {
   assert.equal(
     shouldDropSitemapPath('/docs/user_related_apis_versioned/get-user-bookmarks/'),
@@ -54,6 +69,19 @@ test('drops current generated API and category aliases from the sitemap', () => 
   assert.equal(shouldDropSitemapPath('/docs/category/content-apis/'), true);
   assert.equal(
     shouldDropSitemapPath('/docs/category/content-apis-4.0.0/'),
+    false,
+  );
+});
+
+test('drops explicit Search Console redirect sources from the sitemap', () => {
+  assert.equal(
+    shouldDropSitemapPath(
+      '/docs/user_related_apis_versioned/1.0.0/users-controller-delete-account/',
+    ),
+    true,
+  );
+  assert.equal(
+    shouldDropSitemapPath('/docs/user_related_apis_versioned/scopes/'),
     false,
   );
 });

--- a/tests/search-console-coverage-audit.test.cjs
+++ b/tests/search-console-coverage-audit.test.cjs
@@ -356,6 +356,50 @@ test('robots parser prefers specific user-agent groups over wildcard groups', ()
   );
 });
 
+test('robots parser uses only the most specific matching user-agent token', () => {
+  const robotsTxt = [
+    'User-agent: Googlebot',
+    'Disallow: /search',
+    '',
+    'User-agent: Googlebot-News',
+    'Allow: /search',
+    '',
+    'User-agent: *',
+    'Disallow: /search',
+  ].join('\n');
+
+  assert.equal(
+    isPathBlockedByRobots(robotsTxt, '/search/', 'Googlebot-News'),
+    false,
+  );
+  assert.equal(
+    isPathBlockedByRobots(robotsTxt, '/search/', 'Googlebot'),
+    true,
+  );
+});
+
+test('robots parser merges duplicate groups for the selected user-agent token', () => {
+  const robotsTxt = [
+    'User-agent: Googlebot-News',
+    'Disallow: /search',
+    '',
+    'User-agent: Googlebot-News',
+    'Allow: /search/public',
+    '',
+    'User-agent: Googlebot',
+    'Disallow: /',
+  ].join('\n');
+
+  assert.equal(
+    isPathBlockedByRobots(robotsTxt, '/search/private/', 'Googlebot-News'),
+    true,
+  );
+  assert.equal(
+    isPathBlockedByRobots(robotsTxt, '/search/public/', 'Googlebot-News'),
+    false,
+  );
+});
+
 test('sitemap parser decodes loc entries', () => {
   assert.deepEqual(
     [...parseSitemapUrls('<url><loc>https://api-docs.quran.foundation/docs/a&amp;b/</loc></url>')],

--- a/tests/search-console-coverage-audit.test.cjs
+++ b/tests/search-console-coverage-audit.test.cjs
@@ -3,8 +3,12 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  applySearchConsoleIssueChecks,
+  formatFailure,
   parseArgs,
   buildPathForPathname,
+  isPathBlockedByRobots,
+  parseSitemapUrls,
   resolveHttpUrl,
   resolveLocalUrl,
 } = require(path.join(__dirname, '..', 'scripts', 'audit-search-console-coverage.js'));
@@ -167,6 +171,198 @@ test('live audit fails redirect loops', async () => {
   assert.equal(result.finalStatus, 'loop');
 });
 
+test('issue checks require redirected source URLs to be absent from sitemap', async () => {
+  const result = await applySearchConsoleIssueChecks(
+    'https://api-docs.quran.foundation/docs/old-page',
+    'Page with redirect',
+    {
+      ok: true,
+      outcome: 'redirected',
+      finalStatus: 200,
+      finalUrl: 'https://preview.example.com/docs/new-page/',
+    },
+    {
+      robotsTxt: 'User-agent: *\nAllow: /\n',
+      sitemapUrls: new Set([
+        'https://api-docs.quran.foundation/docs/old-page/',
+        'https://api-docs.quran.foundation/docs/new-page/',
+      ]),
+    },
+    {
+      mode: 'live',
+      readIndexSignals: async () => ({
+        canonical: 'https://api-docs.quran.foundation/docs/new-page/',
+        contentType: 'text/html',
+        metaRobots: '',
+        xRobotsTag: '',
+      }),
+    },
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, 'redirect-source-in-sitemap');
+  assert.deepEqual(result.diagnostics, {
+    sourceSitemapUrls: ['https://api-docs.quran.foundation/docs/old-page/'],
+  });
+});
+
+test('formatted audit failures include SEO diagnostics', () => {
+  assert.deepEqual(
+    formatFailure('https://api-docs.quran.foundation/docs/page/', {
+      outcome: 'canonical-url-mismatch',
+      initialStatus: 200,
+      finalStatus: 200,
+      finalUrl: 'https://api-docs.quran.foundation/docs/page/',
+      diagnostics: {
+        canonical: 'https://api-docs.quran.foundation/docs/page',
+        expected: 'https://api-docs.quran.foundation/docs/page/',
+      },
+      chain: [],
+    }),
+    {
+      url: 'https://api-docs.quran.foundation/docs/page/',
+      outcome: 'canonical-url-mismatch',
+      initialStatus: 200,
+      finalStatus: 200,
+      finalUrl: 'https://api-docs.quran.foundation/docs/page/',
+      error: undefined,
+      diagnostics: {
+        canonical: 'https://api-docs.quran.foundation/docs/page',
+        expected: 'https://api-docs.quran.foundation/docs/page/',
+      },
+      chain: [],
+    },
+  );
+});
+
+test('issue checks require final canonical URL to match the exact sitemap URL', async () => {
+  const result = await applySearchConsoleIssueChecks(
+    'https://api-docs.quran.foundation/docs/category/content-apis',
+    'Page with redirect',
+    {
+      ok: true,
+      outcome: 'redirected',
+      finalStatus: 200,
+      finalUrl: 'https://preview.example.com/docs/category/content-apis/',
+    },
+    {
+      robotsTxt: 'User-agent: *\nAllow: /\n',
+      sitemapUrls: new Set([
+        'https://api-docs.quran.foundation/docs/category/content-apis-4.0.0/',
+      ]),
+    },
+    {
+      mode: 'live',
+      readIndexSignals: async () => ({
+        canonical: 'https://api-docs.quran.foundation/docs/category/content-apis-4.0.0/',
+        contentType: 'text/html',
+        metaRobots: '',
+        xRobotsTag: '',
+      }),
+    },
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, 'final-url-not-in-sitemap');
+});
+
+test('indexed-but-blocked issue passes only after robots allow crawl and noindex is visible', async () => {
+  const result = await applySearchConsoleIssueChecks(
+    'https://api-docs.quran.foundation/search/',
+    'Indexed, though blocked by robots.txt',
+    {
+      ok: true,
+      outcome: 'ok',
+      finalStatus: 200,
+      finalUrl: 'https://preview.example.com/search/',
+    },
+    {
+      robotsTxt: 'User-agent: *\nAllow: /\n',
+      sitemapUrls: new Set(),
+    },
+    {
+      mode: 'live',
+      readIndexSignals: async () => ({
+        canonical: 'https://api-docs.quran.foundation/search/',
+        contentType: 'text/html',
+        metaRobots: 'noindex,follow',
+        xRobotsTag: '',
+      }),
+    },
+  );
+
+  assert.equal(result.ok, true);
+});
+
+test('indexed-but-blocked issue fails while robots still disallows the page', async () => {
+  const result = await applySearchConsoleIssueChecks(
+    'https://api-docs.quran.foundation/search/',
+    'Indexed, though blocked by robots.txt',
+    {
+      ok: true,
+      outcome: 'ok',
+      finalStatus: 200,
+      finalUrl: 'https://preview.example.com/search/',
+    },
+    {
+      robotsTxt: 'User-agent: *\nDisallow: /search\n',
+      sitemapUrls: new Set(),
+    },
+    {
+      mode: 'live',
+      readIndexSignals: async () => ({
+        canonical: 'https://api-docs.quran.foundation/search/',
+        contentType: 'text/html',
+        metaRobots: 'noindex,follow',
+        xRobotsTag: '',
+      }),
+    },
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, 'blocked-by-robots');
+});
+
+test('robots parser applies the longest matching allow or disallow rule', () => {
+  assert.equal(
+    isPathBlockedByRobots(
+      'User-agent: *\nDisallow: /search\nAllow: /search/public\n',
+      '/search/private/',
+    ),
+    true,
+  );
+  assert.equal(
+    isPathBlockedByRobots(
+      'User-agent: *\nDisallow: /search\nAllow: /search/public\n',
+      '/search/public/',
+    ),
+    false,
+  );
+});
+
+test('robots parser prefers specific user-agent groups over wildcard groups', () => {
+  assert.equal(
+    isPathBlockedByRobots(
+      [
+        'User-agent: Googlebot',
+        'Allow: /search',
+        '',
+        'User-agent: *',
+        'Disallow: /search',
+      ].join('\n'),
+      '/search/',
+    ),
+    false,
+  );
+});
+
+test('sitemap parser decodes loc entries', () => {
+  assert.deepEqual(
+    [...parseSitemapUrls('<url><loc>https://api-docs.quran.foundation/docs/a&amp;b/</loc></url>')],
+    ['https://api-docs.quran.foundation/docs/a&b/'],
+  );
+});
+
 test('local audit resolves redirects against build paths', () => {
   const redirects = new Map([
     ['/docs/old-page', { status: '301', target: '/docs/new-page/' }],
@@ -182,6 +378,28 @@ test('local audit resolves redirects against build paths', () => {
   assert.equal(result.ok, true);
   assert.equal(result.outcome, 'redirected');
   assert.equal(result.finalStatus, 200);
+});
+
+test('local audit applies redirects before built source files', () => {
+  const redirects = new Map([
+    ['/docs/unversioned-page/', {
+      status: '301',
+      target: '/docs/versioned-page/',
+    }],
+  ]);
+  const result = resolveLocalUrl(
+    'https://api-docs.quran.foundation/docs/unversioned-page/',
+    {
+      redirects,
+      pathExists: (pathname) =>
+        pathname === '/docs/unversioned-page/' ||
+        pathname === '/docs/versioned-page/',
+    },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.outcome, 'redirected');
+  assert.equal(result.finalUrl, 'https://api-docs.quran.foundation/docs/versioned-page/');
 });
 
 test('local audit maps pretty URL routes to index.html build paths', () => {


### PR DESCRIPTION
## Summary
- make `/search/` crawlable but noindexed via robots, page meta, and Cloudflare headers
- add generated redirects and sitemap cleanup for Search Console redirect/canonical issues
- extend the Search Console audit to validate robots/noindex, canonical host, and exact sitemap membership

## Tests
- `node --test tests\search-console-coverage-audit.test.cjs tests\postbuild-seo.test.cjs`
- `git diff --check f01d98c1654dff90cfeafcd0b5d3da395f5e1651`