### PR TITLE
[codex] Fix pre-live user API sidebar

### DIFF
--- a/docs/user_related_apis_prelive/scopes.mdx
+++ b/docs/user_related_apis_prelive/scopes.mdx
@@ -1,6 +1,6 @@
 ---
 id: scopes
-displayed_sidebar: user-related-apis-pre-live
+displayed_sidebar: APIsSidebar
 ---
 
 # OAuth2 Scopes

--- a/scripts/set-api-displayed-sidebars.js
+++ b/scripts/set-api-displayed-sidebars.js
@@ -72,10 +72,6 @@ function getDisplayedSidebarId(filePath) {
     versionDirPattern.test(segment),
   );
 
-  if (pathSegments.join('/').startsWith('docs/user_related_apis_prelive/')) {
-    return 'user-related-apis-pre-live';
-  }
-
   return isVersionedDoc ? 'APIsVersionedSidebar' : 'APIsSidebar';
 }
 

--- a/tests/api-sidebar-cleanup.test.cjs
+++ b/tests/api-sidebar-cleanup.test.cjs
@@ -130,7 +130,7 @@ api: {"postman":{"name":"By Rub el Hizb number"}}
   );
 });
 
-test('uses the dedicated pre-live sidebar for pre-live API docs', () => {
+test('keeps the shared sidebar for pre-live API docs', () => {
   assert.equal(
     getDisplayedSidebarId(
       path.join(
@@ -141,7 +141,7 @@ test('uses the dedicated pre-live sidebar for pre-live API docs', () => {
         'delete-note-by-id.api.mdx',
       ),
     ),
-    'user-related-apis-pre-live',
+    'APIsSidebar',
   );
 });
 


### PR DESCRIPTION
## Summary
- remove the special-case sidebar assignment for pre-live User API docs in the post-generation cleanup script
- keep the pre-live OAuth scopes page on the shared API sidebar
- update the sidebar cleanup regression test to assert the shared sidebar behavior

## Root Cause
The generated pre-live User API docs were still being mapped to `user-related-apis-pre-live`, so regeneration could reintroduce the isolated sidebar.

## Validation
- `node --test tests/api-sidebar-cleanup.test.cjs`