### PR TITLE
[codex] Fix user API category environment switcher

### DIFF
--- a/src/components/UserRelatedApiEnvironmentNotice/renderContext.tsx
+++ b/src/components/UserRelatedApiEnvironmentNotice/renderContext.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const UserRelatedApiEnvironmentNoticeRenderedContext =
+  React.createContext(false);
+
+export const UserRelatedApiEnvironmentNoticeRenderedProvider =
+  UserRelatedApiEnvironmentNoticeRenderedContext.Provider;
+
+export const useUserRelatedApiEnvironmentNoticeRendered = () =>
+  React.useContext(UserRelatedApiEnvironmentNoticeRenderedContext);

--- a/src/theme/ApiItem/Layout/index.tsx
+++ b/src/theme/ApiItem/Layout/index.tsx
@@ -3,20 +3,24 @@ import { useLocation } from "@docusaurus/router";
 import ApiItemLayout from "@theme-original/ApiItem/Layout";
 
 import UserRelatedApiEnvironmentNotice from "@site/src/components/UserRelatedApiEnvironmentNotice";
+import { useUserRelatedApiEnvironmentNoticeRendered } from "@site/src/components/UserRelatedApiEnvironmentNotice/renderContext";
 
 type ApiItemLayoutProps = React.ComponentProps<typeof ApiItemLayout>;
 
 export default function ApiItemLayoutWrapper(props: ApiItemLayoutProps) {
   const { children, ...restProps } = props;
   const location = useLocation();
+  const isNoticeAlreadyRendered = useUserRelatedApiEnvironmentNoticeRendered();
 
   return (
     <ApiItemLayout {...restProps}>
-      <UserRelatedApiEnvironmentNotice
-        hash={location.hash}
-        pathname={location.pathname}
-        search={location.search}
-      />
+      {!isNoticeAlreadyRendered && (
+        <UserRelatedApiEnvironmentNotice
+          hash={location.hash}
+          pathname={location.pathname}
+          search={location.search}
+        />
+      )}
       {children}
     </ApiItemLayout>
   );

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useLocation } from "@docusaurus/router";
+import DocItemLayout from "@theme-original/DocItem/Layout";
+
+import UserRelatedApiEnvironmentNotice from "@site/src/components/UserRelatedApiEnvironmentNotice";
+import { getUserRelatedDocsEnvironment } from "@site/src/components/UserRelatedApiEnvironmentNotice/paths";
+import { UserRelatedApiEnvironmentNoticeRenderedProvider } from "@site/src/components/UserRelatedApiEnvironmentNotice/renderContext";
+
+type DocItemLayoutProps = React.ComponentProps<typeof DocItemLayout>;
+
+export default function DocItemLayoutWrapper(props: DocItemLayoutProps) {
+  const { children, ...restProps } = props;
+  const location = useLocation();
+  const shouldRenderNotice = Boolean(
+    getUserRelatedDocsEnvironment(location.pathname),
+  );
+
+  return (
+    <DocItemLayout {...restProps}>
+      <UserRelatedApiEnvironmentNoticeRenderedProvider
+        value={shouldRenderNotice}
+      >
+        {shouldRenderNotice && (
+          <UserRelatedApiEnvironmentNotice
+            hash={location.hash}
+            pathname={location.pathname}
+            search={location.search}
+          />
+        )}
+        {children}
+      </UserRelatedApiEnvironmentNoticeRenderedProvider>
+    </DocItemLayout>
+  );
+}

--- a/tests/user-related-env-paths.test.cjs
+++ b/tests/user-related-env-paths.test.cjs
@@ -37,6 +37,18 @@ test('detects production and pre-live user-related docs routes', () => {
   assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_versioned/'), 'production');
   assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive'), 'pre-live');
   assert.equal(getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive/'), 'pre-live');
+  assert.equal(
+    getUserRelatedDocsEnvironment('/docs/user_related_apis_versioned/activity-days'),
+    'production',
+  );
+  assert.equal(
+    getUserRelatedDocsEnvironment('/docs/user_related_apis_versioned/1.0.0/activity-days'),
+    'production',
+  );
+  assert.equal(
+    getUserRelatedDocsEnvironment('/docs/user_related_apis_prelive/activity-days'),
+    'pre-live',
+  );
   assert.equal(getUserRelatedDocsEnvironment('/docs/category/user-related-apis'), 'production');
   assert.equal(
     getUserRelatedDocsEnvironment('/docs/category/user-related-apis/'),
@@ -123,14 +135,37 @@ test('maps the current doc route between production and pre-live trees', () => {
     getUserRelatedDocsPath('/docs/category/user-related-apis-pre-live', 'production'),
     '/docs/category/user-related-apis',
   );
+  assert.equal(
+    getUserRelatedDocsPath(
+      '/docs/user_related_apis_versioned/activity-days',
+      'pre-live',
+    ),
+    '/docs/user_related_apis_prelive/activity-days',
+  );
+  assert.equal(
+    getUserRelatedDocsPath(
+      '/docs/user_related_apis_versioned/1.0.0/activity-days',
+      'pre-live',
+    ),
+    '/docs/user_related_apis_prelive/activity-days',
+  );
+  assert.equal(
+    getUserRelatedDocsPath(
+      '/docs/user_related_apis_prelive/activity-days',
+      'production',
+    ),
+    '/docs/user_related_apis_versioned/activity-days',
+  );
 });
 
 test('falls back to the environment intro doc when the target doc does not exist', () => {
   const availablePaths = new Set([
     '/docs/user_related_apis_versioned/get-user-profile',
     '/docs/user_related_apis_versioned/1.1.0/get-user-profile',
+    '/docs/user_related_apis_versioned/activity-days',
     '/docs/user_related_apis_versioned/scopes',
     '/docs/user_related_apis_prelive/get-user-profile',
+    '/docs/user_related_apis_prelive/activity-days',
     '/docs/user_related_apis_prelive/get-sync-mutations',
     '/docs/user_related_apis_prelive/scopes',
   ]);
@@ -216,6 +251,39 @@ test('falls back to the environment intro doc when the target doc does not exist
   );
   assert.equal(categoryToProductionTarget.path, '/docs/category/user-related-apis');
   assert.equal(categoryToProductionTarget.hasEquivalentDoc, true);
+
+  const productionCategoryOverviewTarget = getUserRelatedDocsTarget(
+    '/docs/user_related_apis_versioned/activity-days',
+    'pre-live',
+    { availablePaths },
+  );
+  assert.equal(
+    productionCategoryOverviewTarget.path,
+    '/docs/user_related_apis_prelive/activity-days',
+  );
+  assert.equal(productionCategoryOverviewTarget.hasEquivalentDoc, true);
+
+  const versionedCategoryOverviewTarget = getUserRelatedDocsTarget(
+    '/docs/user_related_apis_versioned/1.1.0/activity-days',
+    'pre-live',
+    { availablePaths },
+  );
+  assert.equal(
+    versionedCategoryOverviewTarget.path,
+    '/docs/user_related_apis_prelive/activity-days',
+  );
+  assert.equal(versionedCategoryOverviewTarget.hasEquivalentDoc, true);
+
+  const preliveCategoryOverviewTarget = getUserRelatedDocsTarget(
+    '/docs/user_related_apis_prelive/activity-days',
+    'production',
+    { availablePaths },
+  );
+  assert.equal(
+    preliveCategoryOverviewTarget.path,
+    '/docs/user_related_apis_versioned/activity-days',
+  );
+  assert.equal(preliveCategoryOverviewTarget.hasEquivalentDoc, true);
 });
 
 test('collects available docs paths from Docusaurus docs data', () => {

--- a/tests/user-related-env-ui.test.cjs
+++ b/tests/user-related-env-ui.test.cjs
@@ -28,6 +28,31 @@ const apiItemLayoutWrapper = fs.readFileSync(
   'utf-8',
 );
 
+const docItemLayoutWrapper = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    'src',
+    'theme',
+    'DocItem',
+    'Layout',
+    'index.tsx',
+  ),
+  'utf-8',
+);
+
+const renderContext = fs.readFileSync(
+  path.join(
+    __dirname,
+    '..',
+    'src',
+    'components',
+    'UserRelatedApiEnvironmentNotice',
+    'renderContext.tsx',
+  ),
+  'utf-8',
+);
+
 test('switcher uses nav semantics and marks the active environment', () => {
   assert.match(noticeComponent, /<nav[\s\S]*aria-label="User-related API environment switcher"/);
   assert.match(noticeComponent, /aria-current=\{isActive \? "page" : undefined\}/);
@@ -36,4 +61,23 @@ test('switcher uses nav semantics and marks the active environment', () => {
 test('ApiItem layout wrapper forwards original props', () => {
   assert.match(apiItemLayoutWrapper, /const \{ children, \.\.\.restProps \} = props;/);
   assert.match(apiItemLayoutWrapper, /<ApiItemLayout \{\.\.\.restProps\}>/);
+});
+
+test('DocItem layout wrapper renders the switcher on user-related docs pages', () => {
+  assert.match(docItemLayoutWrapper, /getUserRelatedDocsEnvironment\(location\.pathname\)/);
+  assert.match(docItemLayoutWrapper, /<UserRelatedApiEnvironmentNoticeRenderedProvider/);
+  assert.match(docItemLayoutWrapper, /shouldRenderNotice && \(/);
+  assert.match(docItemLayoutWrapper, /<DocItemLayout \{\.\.\.restProps\}>/);
+});
+
+test('ApiItem layout wrapper avoids duplicating the doc-level switcher', () => {
+  assert.match(
+    renderContext,
+    /export const useUserRelatedApiEnvironmentNoticeRendered = \(\) =>/,
+  );
+  assert.match(
+    apiItemLayoutWrapper,
+    /const isNoticeAlreadyRendered = useUserRelatedApiEnvironmentNoticeRendered\(\);/,
+  );
+  assert.match(apiItemLayoutWrapper, /!isNoticeAlreadyRendered && \(/);
 });


### PR DESCRIPTION
## Summary
- Render the user-related API environment switcher on normal Docusaurus doc pages, including generated category/tag overview pages.
- Keep the existing API operation-page switcher path, but avoid duplicate notices when both DocItem and ApiItem wrappers are active.
- Add route and UI guard tests for production/pre-live category overview switching.

## Root cause
Generated category overview pages are rendered as regular DocItem pages, while the environment switcher was only mounted through the ApiItem layout used by operation pages.

## Validation
- node --test tests\user-related-env-paths.test.cjs tests\user-related-env-ui.test.cjs
- yarn test