### PR TITLE
Clarify pre-live sync default collection behavior

### DIFF
--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -69,13 +69,13 @@ The Sync API currently tracks these resources. All `/v1/sync` calls also require
 
 :::note Resource IDs vs composite keys
 For `BOOKMARK`, `COLLECTION`, and `NOTE`, sync mutations include a single `resourceId`.
-For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by the collection bookmark schema plus `data.collectionId`: ayah bookmarks use `key`, `verseNumber`, optional `type: "ayah"`, and one of `mushafId` or `mushaf`; surah/juz/page bookmarks use `key`, `type`, and one of `mushafId` or `mushaf`. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`. Pull responses can include `data.bookmarkId` because the backend has already resolved the bookmark to its stored ID.
+For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by a collection-bookmark request body plus `data.collectionId`: ayah bodies use `key` and `verseNumber`, while surah/juz/page bodies use `key`; include `type`, `mushafId`, and `mushaf` according to the collection bookmark schema. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`. Pull responses can include `data.bookmarkId` because the backend has already resolved the bookmark to its stored ID.
 :::
 
 :::note Favorites/default collection
 The Quran.com Favorites collection uses the virtual collection ID `__default__`.
 
-After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. Create mutations use bookmark details from the collection bookmark schema: ayah bookmarks use `key`, `verseNumber`, optional `type: "ayah"`, and one of `mushafId` or `mushaf`; surah/juz/page bookmarks use `key`, `type`, and one of `mushafId` or `mushaf`. Delete mutations may use either `data.bookmarkId` or the same bookmark details. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
+After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. Create mutations use a collection-bookmark request body: ayah bodies use `key` and `verseNumber`, while surah/juz/page bodies use `key`; include `type`, `mushafId`, and `mushaf` according to the collection bookmark schema. Delete mutations may use either `data.bookmarkId` or the same bookmark details. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
 
 Production clients should keep using the direct collection endpoints until `/v1/sync` is promoted to production. Use `POST /v1/collections/__default__/bookmarks` to add Favorites. To remove Favorites, prefer `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` when you have the bookmark ID, or use `DELETE /v1/collections/__default__/bookmarks` with a JSON body containing either `bookmarkId` or the bookmark details.
 :::
@@ -170,7 +170,7 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
 - **Pre-live references** — The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
-- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Create with the collection bookmark schema details: ayah bookmarks use `key`, `verseNumber`, optional `type: "ayah"`, and one of `mushafId` or `mushaf`; surah/juz/page bookmarks use `key`, `type`, and one of `mushafId` or `mushaf`. Delete with either `data.bookmarkId` or bookmark details. Pull default membership from `BOOKMARK.isInDefaultCollection`.
+- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Create with a collection-bookmark request body: ayah bodies use `key` and `verseNumber`, while surah/juz/page bodies use `key`; include `type`, `mushafId`, and `mushaf` according to the collection bookmark schema. Delete with either `data.bookmarkId` or bookmark details. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps
 

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -12,7 +12,7 @@ The Quran.Foundation Sync API enables **offline-first mobile applications** to s
 across devices. This guide covers the core concepts and helps you implement your first sync flow.
 
 :::warning Pre-live only
-The mutation-based Sync API (`GET /v1/sync` and `POST /v1/sync`) is currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints.
+The Sync API endpoints (`GET /v1/sync` and `POST /v1/sync`) are currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints.
 
 Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks` to add Favorites, and `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` or `DELETE /v1/collections/__default__/bookmarks` to remove Favorites.
 :::

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -14,7 +14,7 @@ across devices. This guide covers the core concepts and helps you implement your
 :::warning Pre-live only
 The Sync API endpoints (`GET /v1/sync` and `POST /v1/sync`) are currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints. If the generated API reference shows a production server option for `/v1/sync`, do not use it yet; production `/v1/sync` is not supported until the Sync API is promoted.
 
-Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks` to add Favorites, and `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` or `DELETE /v1/collections/__default__/bookmarks` to remove Favorites.
+Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks` to add Favorites. To remove Favorites, prefer `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` when you have the bookmark ID, or use `DELETE /v1/collections/__default__/bookmarks` with a JSON body containing either `bookmarkId` or the bookmark details.
 :::
 
 ## Overview
@@ -69,7 +69,7 @@ The Sync API currently tracks these resources. All `/v1/sync` calls also require
 
 :::note Resource IDs vs composite keys
 For `BOOKMARK`, `COLLECTION`, and `NOTE`, sync mutations include a single `resourceId`.
-For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`) plus `data.collectionId`. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`.
+For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`) plus `data.collectionId`. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`. Pull responses can include `data.bookmarkId` because the backend has already resolved the bookmark to its stored ID.
 :::
 
 :::note Favorites/default collection
@@ -77,7 +77,7 @@ The Quran.com Favorites collection uses the virtual collection ID `__default__`.
 
 After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. Create mutations use bookmark details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`); delete mutations may use either `data.bookmarkId` or the same bookmark details. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
 
-Production clients should keep using the direct collection endpoints (`POST /v1/collections/__default__/bookmarks`, `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}`, or `DELETE /v1/collections/__default__/bookmarks`) until `/v1/sync` is promoted to production.
+Production clients should keep using the direct collection endpoints until `/v1/sync` is promoted to production. Use `POST /v1/collections/__default__/bookmarks` to add Favorites. To remove Favorites, prefer `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` when you have the bookmark ID, or use `DELETE /v1/collections/__default__/bookmarks` with a JSON body containing either `bookmarkId` or the bookmark details.
 :::
 
 ## Key Concepts

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -169,8 +169,8 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 ## Important Notes
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
-- **Pre-live references** - The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
-- **Favorites/default collection** - Use `COLLECTION_BOOKMARK` with `collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
+- **Pre-live references** — The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
+- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps
 

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -69,13 +69,13 @@ The Sync API currently tracks these resources. All `/v1/sync` calls also require
 
 :::note Resource IDs vs composite keys
 For `BOOKMARK`, `COLLECTION`, and `NOTE`, sync mutations include a single `resourceId`.
-For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`) plus `data.collectionId`. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`. Pull responses can include `data.bookmarkId` because the backend has already resolved the bookmark to its stored ID.
+For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by the collection bookmark schema plus `data.collectionId`: ayah bookmarks use `key`, `verseNumber`, optional `type: "ayah"`, and one of `mushafId` or `mushaf`; surah/juz/page bookmarks use `key`, `type`, and one of `mushafId` or `mushaf`. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`. Pull responses can include `data.bookmarkId` because the backend has already resolved the bookmark to its stored ID.
 :::
 
 :::note Favorites/default collection
 The Quran.com Favorites collection uses the virtual collection ID `__default__`.
 
-After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. Create mutations use bookmark details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`); delete mutations may use either `data.bookmarkId` or the same bookmark details. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
+After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. Create mutations use bookmark details from the collection bookmark schema: ayah bookmarks use `key`, `verseNumber`, optional `type: "ayah"`, and one of `mushafId` or `mushaf`; surah/juz/page bookmarks use `key`, `type`, and one of `mushafId` or `mushaf`. Delete mutations may use either `data.bookmarkId` or the same bookmark details. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
 
 Production clients should keep using the direct collection endpoints until `/v1/sync` is promoted to production. Use `POST /v1/collections/__default__/bookmarks` to add Favorites. To remove Favorites, prefer `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` when you have the bookmark ID, or use `DELETE /v1/collections/__default__/bookmarks` with a JSON body containing either `bookmarkId` or the bookmark details.
 :::
@@ -170,7 +170,7 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
 - **Pre-live references** — The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
-- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Create with bookmark details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`); delete with either `data.bookmarkId` or bookmark details. Pull default membership from `BOOKMARK.isInDefaultCollection`.
+- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Create with the collection bookmark schema details: ayah bookmarks use `key`, `verseNumber`, optional `type: "ayah"`, and one of `mushafId` or `mushaf`; surah/juz/page bookmarks use `key`, `type`, and one of `mushafId` or `mushaf`. Delete with either `data.bookmarkId` or bookmark details. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps
 

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -69,13 +69,13 @@ The Sync API currently tracks these resources. All `/v1/sync` calls also require
 
 :::note Resource IDs vs composite keys
 For `BOOKMARK`, `COLLECTION`, and `NOTE`, sync mutations include a single `resourceId`.
-For `COLLECTION_BOOKMARK`, there is no single ID; use `data.collectionId` and `data.bookmarkId` instead and omit `resourceId` in your mutation.
+For `COLLECTION_BOOKMARK`, there is no single ID; omit `resourceId`. Create mutations identify the bookmark by details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`) plus `data.collectionId`. Delete mutations may use either those same bookmark details or `data.bookmarkId`, always with `data.collectionId`.
 :::
 
 :::note Favorites/default collection
 The Quran.com Favorites collection uses the virtual collection ID `__default__`.
 
-After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
+After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. Create mutations use bookmark details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`); delete mutations may use either `data.bookmarkId` or the same bookmark details. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
 
 Production clients should keep using the direct collection endpoints (`POST /v1/collections/__default__/bookmarks`, `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}`, or `DELETE /v1/collections/__default__/bookmarks`) until `/v1/sync` is promoted to production.
 :::
@@ -170,7 +170,7 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
 - **Pre-live references** — The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
-- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
+- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Create with bookmark details (`key`, `type`, `verseNumber`, and `mushafId`/`mushaf`); delete with either `data.bookmarkId` or bookmark details. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps
 

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -12,9 +12,9 @@ The Quran.Foundation Sync API enables **offline-first mobile applications** to s
 across devices. This guide covers the core concepts and helps you implement your first sync flow.
 
 :::warning Pre-live only
-The mutation-based Sync API (`GET /auth/v1/sync` and `POST /auth/v1/sync`) is currently available in pre-live only. Production clients should continue using the direct User API endpoints until the Sync API is promoted to production.
+The mutation-based Sync API (`GET /v1/sync` and `POST /v1/sync`) is currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints.
 
-For Quran.com Favorites/default collection bookmarks in production, use `POST /auth/v1/collections/__default__/bookmarks`.
+Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks`.
 :::
 
 ## Overview
@@ -75,9 +75,9 @@ For `COLLECTION_BOOKMARK`, there is no single ID; use `data.collectionId` and `d
 :::note Favorites/default collection
 The Quran.com Favorites collection uses the virtual collection ID `__default__`.
 
-After the pre-live backend support is deployed, push Favorites changes through `POST /auth/v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
+After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
 
-Production clients should keep using the direct endpoint `POST /auth/v1/collections/__default__/bookmarks` until `/auth/v1/sync` is promoted to production.
+Production clients should keep using the direct endpoint `POST /v1/collections/__default__/bookmarks` until `/v1/sync` is promoted to production.
 :::
 
 ## Key Concepts
@@ -169,7 +169,7 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 ## Important Notes
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
-- **Pre-live references** - The API reference links above intentionally point to the pre-live Sync API pages while `/auth/v1/sync` remains pre-live-only.
+- **Pre-live references** - The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
 - **Favorites/default collection** - Use `COLLECTION_BOOKMARK` with `collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -12,7 +12,7 @@ The Quran.Foundation Sync API enables **offline-first mobile applications** to s
 across devices. This guide covers the core concepts and helps you implement your first sync flow.
 
 :::warning Pre-live only
-The Sync API endpoints (`GET /v1/sync` and `POST /v1/sync`) are currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints.
+The Sync API endpoints (`GET /v1/sync` and `POST /v1/sync`) are currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints. If the generated API reference shows a production server option for `/v1/sync`, do not use it yet; production `/v1/sync` is not supported until the Sync API is promoted.
 
 Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks` to add Favorites, and `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` or `DELETE /v1/collections/__default__/bookmarks` to remove Favorites.
 :::

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -14,7 +14,7 @@ across devices. This guide covers the core concepts and helps you implement your
 :::warning Pre-live only
 The mutation-based Sync API (`GET /v1/sync` and `POST /v1/sync`) is currently available in pre-live only. Endpoint paths in this guide are relative to the User API auth base URL: `https://apis-prelive.quran.foundation/auth` for pre-live, and `https://apis.quran.foundation/auth` for production direct endpoints.
 
-Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks`.
+Production clients should continue using the direct User API endpoints until the Sync API is promoted to production. For Quran.com Favorites/default collection bookmarks in production, use `POST /v1/collections/__default__/bookmarks` to add Favorites, and `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}` or `DELETE /v1/collections/__default__/bookmarks` to remove Favorites.
 :::
 
 ## Overview
@@ -77,7 +77,7 @@ The Quran.com Favorites collection uses the virtual collection ID `__default__`.
 
 After the pre-live backend support is deployed, push Favorites changes through `POST /v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
 
-Production clients should keep using the direct endpoint `POST /v1/collections/__default__/bookmarks` until `/v1/sync` is promoted to production.
+Production clients should keep using the direct collection endpoints (`POST /v1/collections/__default__/bookmarks`, `DELETE /v1/collections/__default__/bookmarks/{bookmarkId}`, or `DELETE /v1/collections/__default__/bookmarks`) until `/v1/sync` is promoted to production.
 :::
 
 ## Key Concepts
@@ -170,7 +170,7 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
 - **Pre-live references** — The API reference links above intentionally point to the pre-live Sync API pages while `/v1/sync` remains pre-live-only.
-- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
+- **Favorites/default collection** — Use `COLLECTION_BOOKMARK` with `data.collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps
 

--- a/docs/tutorials/sync/getting-started.mdx
+++ b/docs/tutorials/sync/getting-started.mdx
@@ -11,6 +11,12 @@ draft: true
 The Quran.Foundation Sync API enables **offline-first mobile applications** to synchronize user data
 across devices. This guide covers the core concepts and helps you implement your first sync flow.
 
+:::warning Pre-live only
+The mutation-based Sync API (`GET /auth/v1/sync` and `POST /auth/v1/sync`) is currently available in pre-live only. Production clients should continue using the direct User API endpoints until the Sync API is promoted to production.
+
+For Quran.com Favorites/default collection bookmarks in production, use `POST /auth/v1/collections/__default__/bookmarks`.
+:::
+
 ## Overview
 
 The Sync Layer provides:
@@ -64,6 +70,14 @@ The Sync API currently tracks these resources. All `/v1/sync` calls also require
 :::note Resource IDs vs composite keys
 For `BOOKMARK`, `COLLECTION`, and `NOTE`, sync mutations include a single `resourceId`.
 For `COLLECTION_BOOKMARK`, there is no single ID; use `data.collectionId` and `data.bookmarkId` instead and omit `resourceId` in your mutation.
+:::
+
+:::note Favorites/default collection
+The Quran.com Favorites collection uses the virtual collection ID `__default__`.
+
+After the pre-live backend support is deployed, push Favorites changes through `POST /auth/v1/sync` as `COLLECTION_BOOKMARK` mutations with `data.collectionId: "__default__"`. The virtual collection does not create a real `CollectionBookmark` row, so pull-sync clients should read default collection membership from `BOOKMARK.isInDefaultCollection`, not from a separate `COLLECTION_BOOKMARK` mutation.
+
+Production clients should keep using the direct endpoint `POST /auth/v1/collections/__default__/bookmarks` until `/auth/v1/sync` is promoted to production.
 :::
 
 ## Key Concepts
@@ -155,6 +169,8 @@ When `metadataOnly=true`, the response includes only `lastMutationAt` (no pagina
 ## Important Notes
 
 - **Mutation limits** — `POST /v1/sync` accepts a maximum of 100 mutations per request.
+- **Pre-live references** - The API reference links above intentionally point to the pre-live Sync API pages while `/auth/v1/sync` remains pre-live-only.
+- **Favorites/default collection** - Use `COLLECTION_BOOKMARK` with `collectionId: "__default__"` to push default collection membership in pre-live. Pull default membership from `BOOKMARK.isInDefaultCollection`.
 
 ## Next Steps
 


### PR DESCRIPTION
Summary:
- Add a pre-live-only warning for GET/POST /auth/v1/sync.
- Document the production direct-endpoint path for Favorites/default collection bookmarks while sync remains pre-live-only.
- Document __default__ sync push behavior and BOOKMARK.isInDefaultCollection pull behavior.
- Keep links to the pre-live sync API reference pages.

Validation:
- yarn test: passed, 107 tests
- yarn typecheck: passed
- yarn build: failed in existing generated tag pages because they are not associated with sidebar categories; the failure is unrelated to this tutorial edit and reproduced after clearing .docusaurus

Notes:
- Publish this docs change after the backend pre-live PR is deployed.
- These docs intentionally keep /auth/v1/sync marked as pre-live-only while offline sync remains pre-live-only.
- Do not remove the pre-live-only warning until /auth/v1/sync itself is enabled for production.
- Follow-up: after pre-live validation, when the team decides to enable /auth/v1/sync in production, create the production sync promotion PR and include the __default__ behavior as part of that rollout.
- Once /auth/v1/sync is live in production, update the docs to remove the pre-live-only warning and document production sync support for Favorites/default collection bookmarks.