### PR TITLE
Collect multiple redirect URIs in request access form

### DIFF
--- a/docs/tutorials/oidc/client-setup.mdx
+++ b/docs/tutorials/oidc/client-setup.mdx
@@ -39,6 +39,10 @@ For a confidential client, the browser should never hold `client_secret`. The ba
 
 ## Good Default Request
 
+When using [Request Access](/request-access), enter each redirect URI and each
+post-logout redirect URI in its own row. Do not put multiple callback URLs into
+one field.
+
 ```text
 Please provision our Quran Foundation OAuth2 client.
 

--- a/docs/tutorials/oidc/client-setup.mdx
+++ b/docs/tutorials/oidc/client-setup.mdx
@@ -36,23 +36,3 @@ Ask this clearly:
 If Quran Foundation does not explicitly say your client is public, assume it is confidential and plan for backend token exchange.
 
 For a confidential client, the browser should never hold `client_secret`. The backend or BFF keeps it, exchanges the code, refreshes the session, and stores tokens server-side. That is true even if your frontend runs on the edge.
-
-## Good Default Request
-
-When using [Request Access](/request-access), enter each redirect URI and each
-post-logout redirect URI in its own row. Do not put multiple callback URLs into
-one field.
-
-```text
-Please provision our Quran Foundation OAuth2 client.
-
-We need:
-- client_id
-- clarification on whether the client is confidential or public
-- these redirect URIs:
-  - http://localhost:3000/callback
-  - https://app.example.com/callback
-- these post-logout redirect URIs:
-  - http://localhost:3000
-  - https://app.example.com
-```

--- a/docs/tutorials/oidc/client-setup.mdx
+++ b/docs/tutorials/oidc/client-setup.mdx
@@ -15,7 +15,7 @@ Allowed runtimes: Any.
 Required credentials: None yet.
 Minimal import: None.
 
-## What You Need To Send
+## What The Request Access Form Asks For
 
 | Field                     | Why it matters                                |
 | ------------------------- | --------------------------------------------- |
@@ -26,6 +26,9 @@ Minimal import: None.
 | Privacy policy URL        | Required for trust and compliance             |
 | Terms of service URL      | Required for trust and compliance             |
 | Logo URL                  | Optional, but improves consent screen clarity |
+
+Use [Request Access](/request-access) to submit these details. For redirect
+URIs and post-logout redirect URIs, add each URL in its own row.
 
 ## Important Question
 

--- a/src/pages/request-access-utils.cjs
+++ b/src/pages/request-access-utils.cjs
@@ -1,0 +1,192 @@
+const URI_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"',\]]+/gi;
+
+const createEmptyUriField = () => ({ value: '' });
+
+const createDefaultFormValues = () => ({
+    appName: '',
+    email: '',
+    callbackUrl: '',
+    redirectUris: [createEmptyUriField()],
+    logoUri: '',
+    clientUri: '',
+    policyUri: '',
+    tosUri: '',
+    postLogoutRedirectUris: [createEmptyUriField()],
+    agreementsAccepted: false,
+});
+
+const normalizeOptionalValue = (value) => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+};
+
+const cleanUriToken = (value) => {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    return value
+        .trim()
+        .replace(/^\s*[-*]\s+/, '')
+        .replace(/^[\s"'`\[\],]+/, '')
+        .replace(/[\s"'`\],]+$/, '')
+        .trim();
+};
+
+const dedupeUriValues = (values) => {
+    const deduped = [];
+    const seen = new Set();
+
+    values.forEach((value) => {
+        const uri = cleanUriToken(value);
+        if (!uri || seen.has(uri)) {
+            return;
+        }
+
+        seen.add(uri);
+        deduped.push(uri);
+    });
+
+    return deduped;
+};
+
+const parsePastedUriValues = (value) => {
+    if (typeof value !== 'string') {
+        return [];
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return [];
+    }
+
+    if (trimmed.startsWith('[')) {
+        try {
+            const parsedValue = JSON.parse(trimmed);
+            if (Array.isArray(parsedValue)) {
+                return dedupeUriValues(parsedValue);
+            }
+        } catch (error) {
+            // Fall through to forgiving text parsing for JSON-ish snippets.
+        }
+    }
+
+    const urlMatches = trimmed.match(URI_PATTERN);
+    if (urlMatches?.length) {
+        return dedupeUriValues(urlMatches);
+    }
+
+    return dedupeUriValues(trimmed.split(/[\r\n,]+/));
+};
+
+const valuesFromUriField = (value) => {
+    if (!value) {
+        return [];
+    }
+
+    if (Array.isArray(value)) {
+        return value.flatMap((entry) => {
+            if (typeof entry === 'string') {
+                return [entry];
+            }
+            if (entry && typeof entry.value === 'string') {
+                return [entry.value];
+            }
+            return [];
+        });
+    }
+
+    if (typeof value === 'string') {
+        return [value];
+    }
+
+    return [];
+};
+
+const normalizeUriList = (value) =>
+    dedupeUriValues(
+        valuesFromUriField(value).flatMap((entry) => {
+            const parsedValues = parsePastedUriValues(entry);
+            return parsedValues.length ? parsedValues : [entry];
+        })
+    );
+
+const toUriFields = (value) => {
+    const uris = normalizeUriList(value);
+    return uris.length ? uris.map((uri) => ({ value: uri })) : [createEmptyUriField()];
+};
+
+function sanitizeFormValues(values) {
+    if (!values || typeof values !== 'object') {
+        return createDefaultFormValues();
+    }
+
+    const redirectUris = toUriFields(
+        values.redirectUris || values.redirect_uris || values.callbackUrl
+    );
+    const postLogoutRedirectUris = toUriFields(
+        values.postLogoutRedirectUris || values.post_logout_redirect_uris
+    );
+
+    return {
+        ...createDefaultFormValues(),
+        appName: typeof values.appName === 'string' ? values.appName : '',
+        email: typeof values.email === 'string' ? values.email : '',
+        callbackUrl: redirectUris[0]?.value || '',
+        redirectUris,
+        logoUri: typeof values.logoUri === 'string' ? values.logoUri : '',
+        clientUri: typeof values.clientUri === 'string' ? values.clientUri : '',
+        policyUri: typeof values.policyUri === 'string' ? values.policyUri : '',
+        tosUri: typeof values.tosUri === 'string' ? values.tosUri : '',
+        postLogoutRedirectUris,
+        agreementsAccepted: Boolean(values.agreementsAccepted),
+    };
+}
+
+function isEmptyFormValues(values) {
+    return (
+        !values.appName &&
+        !values.email &&
+        !normalizeUriList(values.redirectUris).length &&
+        !values.logoUri &&
+        !values.clientUri &&
+        !values.policyUri &&
+        !values.tosUri &&
+        !normalizeUriList(values.postLogoutRedirectUris).length &&
+        !values.agreementsAccepted
+    );
+}
+
+const validateSingleUri = (value) => {
+    const uri = normalizeOptionalValue(value);
+    if (!uri) {
+        return true;
+    }
+
+    if (/\s/.test(uri)) {
+        return 'Enter one URI per row';
+    }
+
+    try {
+        new URL(uri);
+        return true;
+    } catch (error) {
+        return 'Enter a valid URL';
+    }
+};
+
+module.exports = {
+    createDefaultFormValues,
+    createEmptyUriField,
+    dedupeUriValues,
+    isEmptyFormValues,
+    normalizeOptionalValue,
+    normalizeUriList,
+    parsePastedUriValues,
+    sanitizeFormValues,
+    validateSingleUri,
+    valuesFromUriField,
+};

--- a/src/pages/request-access-utils.cjs
+++ b/src/pages/request-access-utils.cjs
@@ -1,4 +1,5 @@
 const URI_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"',\]]+/gi;
+const QUOTED_URI_SEPARATOR_PATTERN = /["']\s*,\s*["']/;
 
 const createEmptyUriField = () => ({ value: '' });
 
@@ -53,6 +54,19 @@ const dedupeUriValues = (values) => {
     return deduped;
 };
 
+const isValidSingleUriValue = (value) => {
+    if (!value || /\s/.test(value)) {
+        return false;
+    }
+
+    try {
+        new URL(value);
+        return true;
+    } catch (error) {
+        return false;
+    }
+};
+
 const parsePastedUriValues = (value) => {
     if (typeof value !== 'string') {
         return [];
@@ -74,12 +88,32 @@ const parsePastedUriValues = (value) => {
         }
     }
 
+    const cleanedValue = cleanUriToken(trimmed);
+    if (!/[\r\n]/.test(trimmed) && !QUOTED_URI_SEPARATOR_PATTERN.test(trimmed)) {
+        return isValidSingleUriValue(cleanedValue) ? [cleanedValue] : [];
+    }
+
+    if (/[\r\n]/.test(trimmed)) {
+        return dedupeUriValues(trimmed.split(/[\r\n]+/));
+    }
+
+    if (QUOTED_URI_SEPARATOR_PATTERN.test(trimmed)) {
+        try {
+            const parsedValue = JSON.parse(`[${trimmed}]`);
+            if (Array.isArray(parsedValue)) {
+                return dedupeUriValues(parsedValue);
+            }
+        } catch (error) {
+            // Fall through to URI matching for JSON-ish snippets.
+        }
+    }
+
     const urlMatches = trimmed.match(URI_PATTERN);
     if (urlMatches?.length) {
         return dedupeUriValues(urlMatches);
     }
 
-    return dedupeUriValues(trimmed.split(/[\r\n,]+/));
+    return [];
 };
 
 const valuesFromUriField = (value) => {
@@ -106,16 +140,18 @@ const valuesFromUriField = (value) => {
     return [];
 };
 
-const normalizeUriList = (value) =>
+const normalizeUriList = (value) => dedupeUriValues(valuesFromUriField(value));
+
+const normalizeLegacyUriList = (value) =>
     dedupeUriValues(
         valuesFromUriField(value).flatMap((entry) => {
             const parsedValues = parsePastedUriValues(entry);
-            return parsedValues.length ? parsedValues : [entry];
+            return parsedValues.length > 1 ? parsedValues : [entry];
         })
     );
 
-const toUriFields = (value) => {
-    const uris = normalizeUriList(value);
+const toUriFields = (value, parseLegacyValue = false) => {
+    const uris = parseLegacyValue ? normalizeLegacyUriList(value) : normalizeUriList(value);
     return uris.length ? uris.map((uri) => ({ value: uri })) : [createEmptyUriField()];
 };
 
@@ -124,11 +160,16 @@ function sanitizeFormValues(values) {
         return createDefaultFormValues();
     }
 
+    const redirectUriSource = values.redirectUris || values.redirect_uris || values.callbackUrl;
+    const postLogoutRedirectUriSource =
+        values.postLogoutRedirectUris || values.post_logout_redirect_uris;
     const redirectUris = toUriFields(
-        values.redirectUris || values.redirect_uris || values.callbackUrl
+        redirectUriSource,
+        typeof redirectUriSource === 'string'
     );
     const postLogoutRedirectUris = toUriFields(
-        values.postLogoutRedirectUris || values.post_logout_redirect_uris
+        postLogoutRedirectUriSource,
+        typeof postLogoutRedirectUriSource === 'string'
     );
 
     return {

--- a/src/pages/request-access-utils.cjs
+++ b/src/pages/request-access-utils.cjs
@@ -1,5 +1,6 @@
 const URI_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"',\]]+/gi;
 const QUOTED_URI_SEPARATOR_PATTERN = /["']\s*,\s*["']/;
+const URI_LIST_SEPARATOR_PATTERN = /,\s*[a-z][a-z0-9+.-]*:\/\//i;
 
 const createEmptyUriField = () => ({ value: '' });
 
@@ -67,6 +68,16 @@ const isValidSingleUriValue = (value) => {
     }
 };
 
+const hasUriListSeparatorBeforeQuery = (value) => {
+    const separatorMatch = value.match(URI_LIST_SEPARATOR_PATTERN);
+    if (!separatorMatch || typeof separatorMatch.index !== 'number') {
+        return false;
+    }
+
+    const queryIndex = value.search(/[?#]/);
+    return queryIndex === -1 || separatorMatch.index < queryIndex;
+};
+
 const parsePastedUriValues = (value) => {
     if (typeof value !== 'string') {
         return [];
@@ -89,8 +100,13 @@ const parsePastedUriValues = (value) => {
     }
 
     const cleanedValue = cleanUriToken(trimmed);
-    if (!/[\r\n]/.test(trimmed) && !QUOTED_URI_SEPARATOR_PATTERN.test(trimmed)) {
-        return isValidSingleUriValue(cleanedValue) ? [cleanedValue] : [];
+    if (
+        !/[\r\n]/.test(trimmed) &&
+        !QUOTED_URI_SEPARATOR_PATTERN.test(trimmed) &&
+        isValidSingleUriValue(cleanedValue) &&
+        !hasUriListSeparatorBeforeQuery(cleanedValue)
+    ) {
+        return [cleanedValue];
     }
 
     if (/[\r\n]/.test(trimmed)) {

--- a/src/pages/request-access.js
+++ b/src/pages/request-access.js
@@ -2,75 +2,58 @@ import React, { useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import { useForm } from 'react-hook-form';
+import { useFieldArray, useForm } from 'react-hook-form';
 import styles from './request-access.module.css';
 import {
     DeveloperBenefitsModal,
     DeveloperDisclaimersModal,
 } from '@site/src/components/DeveloperModals';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import requestAccessUtils from './request-access-utils.cjs';
 
 const REQUEST_ACCESS_FORM_STORAGE_KEY = 'qf:request-access-form:v1';
-
-const DEFAULT_FORM_VALUES = {
-    appName: '',
-    email: '',
-    callbackUrl: '',
-    logoUri: '',
-    clientUri: '',
-    policyUri: '',
-    tosUri: '',
-    postLogoutRedirectUris: '',
-    agreementsAccepted: false,
-};
-
-const normalizeOptionalValue = (value) => {
-    if (typeof value !== 'string') {
-        return undefined;
-    }
-    const trimmed = value.trim();
-    return trimmed ? trimmed : undefined;
-};
-
-function sanitizeFormValues(values) {
-    if (!values || typeof values !== 'object') {
-        return { ...DEFAULT_FORM_VALUES };
-    }
-
-    return {
-        ...DEFAULT_FORM_VALUES,
-        appName: typeof values.appName === 'string' ? values.appName : '',
-        email: typeof values.email === 'string' ? values.email : '',
-        callbackUrl: typeof values.callbackUrl === 'string' ? values.callbackUrl : '',
-        logoUri: typeof values.logoUri === 'string' ? values.logoUri : '',
-        clientUri: typeof values.clientUri === 'string' ? values.clientUri : '',
-        policyUri: typeof values.policyUri === 'string' ? values.policyUri : '',
-        tosUri: typeof values.tosUri === 'string' ? values.tosUri : '',
-        postLogoutRedirectUris:
-            typeof values.postLogoutRedirectUris === 'string'
-                ? values.postLogoutRedirectUris
-                : '',
-        agreementsAccepted: Boolean(values.agreementsAccepted),
-    };
-}
-
-function isEmptyFormValues(values) {
-    return (
-        !values.appName &&
-        !values.email &&
-        !values.callbackUrl &&
-        !values.logoUri &&
-        !values.clientUri &&
-        !values.policyUri &&
-        !values.tosUri &&
-        !values.postLogoutRedirectUris &&
-        !values.agreementsAccepted
-    );
-}
+const {
+    createDefaultFormValues,
+    createEmptyUriField,
+    dedupeUriValues,
+    isEmptyFormValues,
+    normalizeOptionalValue,
+    normalizeUriList,
+    parsePastedUriValues,
+    sanitizeFormValues,
+    validateSingleUri,
+    valuesFromUriField,
+} = requestAccessUtils;
 
 export default function RequestAccess() {
-    const { register, handleSubmit, formState: { errors }, reset, watch } = useForm({
-        defaultValues: DEFAULT_FORM_VALUES,
+    const {
+        register,
+        handleSubmit,
+        control,
+        formState: { errors },
+        getValues,
+        reset,
+        watch,
+    } = useForm({
+        defaultValues: createDefaultFormValues(),
+    });
+    const {
+        fields: redirectUriFields,
+        append: appendRedirectUri,
+        remove: removeRedirectUri,
+        replace: replaceRedirectUris,
+    } = useFieldArray({
+        control,
+        name: 'redirectUris',
+    });
+    const {
+        fields: postLogoutRedirectUriFields,
+        append: appendPostLogoutRedirectUri,
+        remove: removePostLogoutRedirectUri,
+        replace: replacePostLogoutRedirectUris,
+    } = useFieldArray({
+        control,
+        name: 'postLogoutRedirectUris',
     });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitStatus, setSubmitStatus] = useState(null);
@@ -82,7 +65,6 @@ export default function RequestAccess() {
     const apiBaseUrl =
         siteConfig.customFields?.scopeRequestApiBaseUrl ||
         'https://qf-form-handler.fly.dev';
-    
 
     useEffect(() => {
         if (typeof window === 'undefined') {
@@ -123,22 +105,55 @@ export default function RequestAccess() {
 
     const closeModal = useCallback(() => setActiveModal(null), []);
 
+    const handleUriPaste = useCallback(
+        (event, fieldName, index, replaceRows) => {
+            const pastedText = event.clipboardData?.getData('text');
+            const pastedValues = parsePastedUriValues(pastedText);
+            if (pastedValues.length <= 1) {
+                return;
+            }
+
+            event.preventDefault();
+            const currentValues = getValues(fieldName);
+            const existingValues = valuesFromUriField(currentValues);
+            const nextValues = dedupeUriValues([
+                ...existingValues.slice(0, index),
+                ...pastedValues,
+                ...existingValues.slice(index + 1),
+            ]);
+            replaceRows(
+                nextValues.length
+                    ? nextValues.map((uri) => ({ value: uri }))
+                    : [createEmptyUriField()]
+            );
+        },
+        [getValues]
+    );
+
+    const removeUriRow = useCallback((fields, removeRow, replaceRows, index) => {
+        if (fields.length <= 1) {
+            replaceRows([createEmptyUriField()]);
+            return;
+        }
+        removeRow(index);
+    }, []);
+
     const onSubmit = async (data) => {
         setIsSubmitting(true);
         setSubmitError('');
-        const redirectUri = normalizeOptionalValue(data.callbackUrl);
-        const postLogoutRedirectUri = normalizeOptionalValue(data.postLogoutRedirectUris);
+        const redirectUris = normalizeUriList(data.redirectUris);
+        const postLogoutRedirectUris = normalizeUriList(data.postLogoutRedirectUris);
         const payload = {
             appName: data.appName,
             email: data.email,
-            callbackUrl: redirectUri,
+            callbackUrl: redirectUris[0],
             agreementsAccepted: data.agreementsAccepted,
             logo_uri: normalizeOptionalValue(data.logoUri),
             client_uri: normalizeOptionalValue(data.clientUri),
             policy_uri: normalizeOptionalValue(data.policyUri),
             tos_uri: normalizeOptionalValue(data.tosUri),
-            redirect_uris: redirectUri,
-            post_logout_redirect_uris: postLogoutRedirectUri,
+            redirect_uris: redirectUris,
+            post_logout_redirect_uris: postLogoutRedirectUris,
         };
         try {
             const response = await fetch(`${apiBaseUrl}/api/v1/webhook`, {
@@ -146,7 +161,7 @@ export default function RequestAccess() {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify(payload)
+                body: JSON.stringify(payload),
             });
 
             if (!response.ok) {
@@ -160,7 +175,7 @@ export default function RequestAccess() {
             }
 
             setSubmitStatus('success');
-            reset();
+            reset(createDefaultFormValues());
             if (typeof window !== 'undefined') {
                 window.sessionStorage.removeItem(REQUEST_ACCESS_FORM_STORAGE_KEY);
             }
@@ -250,18 +265,64 @@ export default function RequestAccess() {
                                 </p>
                             </div>
                             <div className="margin-bottom--md">
-                                <label htmlFor="callbackUrl" className="form-label">
-                                    Redirect URI
-                                </label>
-                                <input
-                                    type="url"
-                                    id="callbackUrl"
-                                    className="form-input"
-                                    placeholder="https://your-app.com/callback"
-                                    {...register('callbackUrl')}
-                                />
+                                <label className="form-label">Redirect URIs</label>
+                                <div className={styles.uriList}>
+                                    {redirectUriFields.map((field, index) => {
+                                        const fieldError = errors.redirectUris?.[index]?.value;
+                                        return (
+                                            <div key={field.id} className={styles.uriRow}>
+                                                <div className={styles.uriInput}>
+                                                    <input
+                                                        type="url"
+                                                        id={`redirectUris-${index}`}
+                                                        className={`form-input ${fieldError ? 'form-input-error' : ''}`}
+                                                        placeholder="https://your-app.com/callback"
+                                                        aria-label={`Redirect URI ${index + 1}`}
+                                                        {...register(`redirectUris.${index}.value`, {
+                                                            validate: validateSingleUri,
+                                                        })}
+                                                        onPaste={(event) =>
+                                                            handleUriPaste(
+                                                                event,
+                                                                'redirectUris',
+                                                                index,
+                                                                replaceRedirectUris
+                                                            )
+                                                        }
+                                                    />
+                                                    {fieldError && (
+                                                        <div className="error-message">
+                                                            {fieldError.message}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                                <button
+                                                    type="button"
+                                                    className={styles.removeUriButton}
+                                                    onClick={() =>
+                                                        removeUriRow(
+                                                            redirectUriFields,
+                                                            removeRedirectUri,
+                                                            replaceRedirectUris,
+                                                            index
+                                                        )
+                                                    }
+                                                >
+                                                    Remove
+                                                </button>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                                <button
+                                    type="button"
+                                    className={styles.addUriButton}
+                                    onClick={() => appendRedirectUri(createEmptyUriField())}
+                                >
+                                    Add redirect URI
+                                </button>
                                 <small className="text-muted">
-                                    OAuth callback URL. Example: https://your-app.com/callback or http://localhost:3000/callback.
+                                    OAuth callback URLs. Add each callback URL in its own row.
                                 </small>
                             </div>
 
@@ -318,19 +379,71 @@ export default function RequestAccess() {
                             </div>
 
                             <div className="margin-bottom--md">
-                                <label htmlFor="postLogoutRedirectUris" className="form-label">
-                                    Post-logout Redirect URI
-                                </label>
-                                <input
-                                    type="url"
-                                    id="postLogoutRedirectUris"
-                                    className="form-input"
-                                    placeholder="https://your-app.com/"
-                                    {...register('postLogoutRedirectUris')}
-                                />
+                                <label className="form-label">Post-logout Redirect URIs</label>
+                                <div className={styles.uriList}>
+                                    {postLogoutRedirectUriFields.map((field, index) => {
+                                        const fieldError =
+                                            errors.postLogoutRedirectUris?.[index]?.value;
+                                        return (
+                                            <div key={field.id} className={styles.uriRow}>
+                                                <div className={styles.uriInput}>
+                                                    <input
+                                                        type="url"
+                                                        id={`postLogoutRedirectUris-${index}`}
+                                                        className={`form-input ${fieldError ? 'form-input-error' : ''}`}
+                                                        placeholder="https://your-app.com/"
+                                                        aria-label={`Post-logout Redirect URI ${index + 1}`}
+                                                        {...register(
+                                                            `postLogoutRedirectUris.${index}.value`,
+                                                            {
+                                                                validate: validateSingleUri,
+                                                            }
+                                                        )}
+                                                        onPaste={(event) =>
+                                                            handleUriPaste(
+                                                                event,
+                                                                'postLogoutRedirectUris',
+                                                                index,
+                                                                replacePostLogoutRedirectUris
+                                                            )
+                                                        }
+                                                    />
+                                                    {fieldError && (
+                                                        <div className="error-message">
+                                                            {fieldError.message}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                                <button
+                                                    type="button"
+                                                    className={styles.removeUriButton}
+                                                    onClick={() =>
+                                                        removeUriRow(
+                                                            postLogoutRedirectUriFields,
+                                                            removePostLogoutRedirectUri,
+                                                            replacePostLogoutRedirectUris,
+                                                            index
+                                                        )
+                                                    }
+                                                >
+                                                    Remove
+                                                </button>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                                <button
+                                    type="button"
+                                    className={styles.addUriButton}
+                                    onClick={() =>
+                                        appendPostLogoutRedirectUri(createEmptyUriField())
+                                    }
+                                >
+                                    Add post-logout URI
+                                </button>
                                 <small className="text-muted">
-                                    Optional: Must match Redirect URI scheme, domain, and port.
-                                    Example: https://your-app.com/logout or http://localhost:3000/logout.
+                                    Optional. Each post-logout URI must match the scheme, domain,
+                                    and port of one redirect URI.
                                 </small>
                             </div>
 

--- a/src/pages/request-access.js
+++ b/src/pages/request-access.js
@@ -155,15 +155,19 @@ export default function RequestAccess() {
         const payload = {
             appName: data.appName,
             email: data.email,
-            callbackUrl: redirectUris[0],
             agreementsAccepted: data.agreementsAccepted,
             logo_uri: normalizeOptionalValue(data.logoUri),
             client_uri: normalizeOptionalValue(data.clientUri),
             policy_uri: normalizeOptionalValue(data.policyUri),
             tos_uri: normalizeOptionalValue(data.tosUri),
-            redirect_uris: redirectUris,
-            post_logout_redirect_uris: postLogoutRedirectUris,
         };
+        if (redirectUris.length) {
+            payload.callbackUrl = redirectUris[0];
+            payload.redirect_uris = redirectUris;
+        }
+        if (postLogoutRedirectUris.length) {
+            payload.post_logout_redirect_uris = postLogoutRedirectUris;
+        }
         try {
             const response = await fetch(`${apiBaseUrl}/api/v1/webhook`, {
                 method: 'POST',

--- a/src/pages/request-access.js
+++ b/src/pages/request-access.js
@@ -277,8 +277,10 @@ export default function RequestAccess() {
                                     Only needed if you plan to use OAuth2 flows or user-related APIs
                                 </p>
                             </div>
-                            <div className="margin-bottom--md">
-                                <label className="form-label">Redirect URIs</label>
+                            <fieldset className={clsx('margin-bottom--md', styles.uriFieldset)}>
+                                <legend className={clsx('form-label', styles.uriLegend)}>
+                                    Redirect URIs
+                                </legend>
                                 <div className={styles.uriList}>
                                     {redirectUriFields.map((field, index) => {
                                         const fieldError = errors.redirectUris?.[index]?.value;
@@ -337,7 +339,7 @@ export default function RequestAccess() {
                                 <small className={clsx('text-muted', styles.uriHelpText)}>
                                     OAuth callback URLs. Add each callback URL in its own row.
                                 </small>
-                            </div>
+                            </fieldset>
 
                             <div className="margin-bottom--md">
                                 <label htmlFor="logoUri" className="form-label">
@@ -391,8 +393,10 @@ export default function RequestAccess() {
                                 />
                             </div>
 
-                            <div className="margin-bottom--md">
-                                <label className="form-label">Post-logout Redirect URIs</label>
+                            <fieldset className={clsx('margin-bottom--md', styles.uriFieldset)}>
+                                <legend className={clsx('form-label', styles.uriLegend)}>
+                                    Post-logout Redirect URIs
+                                </legend>
                                 <div className={styles.uriList}>
                                     {postLogoutRedirectUriFields.map((field, index) => {
                                         const fieldError =
@@ -458,7 +462,7 @@ export default function RequestAccess() {
                                     Optional. Each post-logout URI must match the scheme, domain,
                                     and port of one redirect URI.
                                 </small>
-                            </div>
+                            </fieldset>
 
                             <div className="margin-bottom--md">
                                 <div>

--- a/src/pages/request-access.js
+++ b/src/pages/request-access.js
@@ -33,6 +33,7 @@ export default function RequestAccess() {
         formState: { errors },
         getValues,
         reset,
+        setValue,
         watch,
     } = useForm({
         defaultValues: createDefaultFormValues(),
@@ -109,11 +110,19 @@ export default function RequestAccess() {
         (event, fieldName, index, replaceRows) => {
             const pastedText = event.clipboardData?.getData('text');
             const pastedValues = parsePastedUriValues(pastedText);
-            if (pastedValues.length <= 1) {
+            if (!pastedValues.length) {
                 return;
             }
 
             event.preventDefault();
+            if (pastedValues.length === 1) {
+                setValue(`${fieldName}.${index}.value`, pastedValues[0], {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                });
+                return;
+            }
+
             const currentValues = getValues(fieldName);
             const existingValues = valuesFromUriField(currentValues);
             const nextValues = dedupeUriValues([
@@ -127,7 +136,7 @@ export default function RequestAccess() {
                     : [createEmptyUriField()]
             );
         },
-        [getValues]
+        [getValues, setValue]
     );
 
     const removeUriRow = useCallback((fields, removeRow, replaceRows, index) => {
@@ -319,9 +328,9 @@ export default function RequestAccess() {
                                     className={styles.addUriButton}
                                     onClick={() => appendRedirectUri(createEmptyUriField())}
                                 >
-                                    Add redirect URI
+                                    Add another redirect URI
                                 </button>
-                                <small className="text-muted">
+                                <small className={clsx('text-muted', styles.uriHelpText)}>
                                     OAuth callback URLs. Add each callback URL in its own row.
                                 </small>
                             </div>
@@ -439,9 +448,9 @@ export default function RequestAccess() {
                                         appendPostLogoutRedirectUri(createEmptyUriField())
                                     }
                                 >
-                                    Add post-logout URI
+                                    Add another post-logout URI
                                 </button>
-                                <small className="text-muted">
+                                <small className={clsx('text-muted', styles.uriHelpText)}>
                                     Optional. Each post-logout URI must match the scheme, domain,
                                     and port of one redirect URI.
                                 </small>

--- a/src/pages/request-access.module.css
+++ b/src/pages/request-access.module.css
@@ -75,6 +75,18 @@
   border-top: 1px solid var(--qf-border-card);
 }
 
+.uriFieldset {
+  border: 0;
+  margin-left: 0;
+  margin-right: 0;
+  min-inline-size: 0;
+  padding: 0;
+}
+
+.uriLegend {
+  padding: 0;
+}
+
 .uriList {
   display: flex;
   flex-direction: column;

--- a/src/pages/request-access.module.css
+++ b/src/pages/request-access.module.css
@@ -74,3 +74,66 @@
   border: 0;
   border-top: 1px solid var(--qf-border-card);
 }
+
+.uriList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.uriRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.uriInput {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.removeUriButton,
+.addUriButton {
+  border-radius: var(--ifm-global-radius);
+  font-weight: 600;
+  min-height: 38px;
+  white-space: nowrap;
+}
+
+.removeUriButton {
+  background: var(--qf-surface-card);
+  border: 1px solid var(--qf-border-card);
+  color: var(--qf-text-muted);
+  padding: 0.5rem 0.75rem;
+}
+
+.removeUriButton:hover {
+  border-color: var(--ifm-color-danger);
+  color: var(--ifm-color-danger);
+}
+
+.addUriButton {
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--qf-border-card);
+  color: var(--qf-text-primary);
+  margin-bottom: 0.35rem;
+  padding: 0.5rem 0.85rem;
+}
+
+.addUriButton:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+@media (max-width: 480px) {
+  .uriRow {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .removeUriButton,
+  .addUriButton {
+    width: 100%;
+  }
+}

--- a/src/pages/request-access.module.css
+++ b/src/pages/request-access.module.css
@@ -117,13 +117,20 @@
   background: var(--ifm-color-emphasis-100);
   border: 1px solid var(--qf-border-card);
   color: var(--qf-text-primary);
-  margin-bottom: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 0;
   padding: 0.5rem 0.85rem;
 }
 
 .addUriButton:hover {
   border-color: var(--ifm-color-primary);
   color: var(--ifm-color-primary);
+}
+
+.uriHelpText {
+  display: block;
+  margin-top: 0.5rem;
 }
 
 @media (max-width: 480px) {

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -172,3 +172,24 @@ test("request access page uses clearer add uri button copy", () => {
   assert.match(page, /uriHelpText/);
   assert.match(styles, /\.uriHelpText/);
 });
+
+test("request access page uses fieldset legends for uri groups", () => {
+  const page = read("src", "pages", "request-access.js");
+  const styles = read("src", "pages", "request-access.module.css");
+
+  assert.match(
+    page,
+    /<fieldset className=\{clsx\('margin-bottom--md', styles\.uriFieldset\)\}>[\s\S]*<legend className=\{clsx\('form-label', styles\.uriLegend\)\}>[\s\S]*Redirect URIs/
+  );
+  assert.match(
+    page,
+    /<fieldset className=\{clsx\('margin-bottom--md', styles\.uriFieldset\)\}>[\s\S]*<legend className=\{clsx\('form-label', styles\.uriLegend\)\}>[\s\S]*Post-logout Redirect URIs/
+  );
+  assert.doesNotMatch(page, /<label className="form-label">Redirect URIs<\/label>/);
+  assert.doesNotMatch(
+    page,
+    /<label className="form-label">Post-logout Redirect URIs<\/label>/
+  );
+  assert.match(styles, /\.uriFieldset/);
+  assert.match(styles, /\.uriLegend/);
+});

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -95,6 +95,20 @@ test("request access paste parser splits common multi-uri snippets", () => {
 
   assert.deepEqual(
     parsePastedUriValues(
+      "https://app.example.com/callback, https://admin.example.com/callback"
+    ),
+    ["https://app.example.com/callback", "https://admin.example.com/callback"]
+  );
+
+  assert.deepEqual(
+    parsePastedUriValues(
+      "https://app.example.com/callback,https://admin.example.com/callback"
+    ),
+    ["https://app.example.com/callback", "https://admin.example.com/callback"]
+  );
+
+  assert.deepEqual(
+    parsePastedUriValues(
       '["https://app.example.com/logout", "http://localhost:3000/logout"]'
     ),
     ["https://app.example.com/logout", "http://localhost:3000/logout"]
@@ -105,6 +119,15 @@ test("request access paste parser preserves commas inside a single uri", () => {
   assert.deepEqual(
     parsePastedUriValues("https://app.example.com/callback?aud=mobile,web"),
     ["https://app.example.com/callback?aud=mobile,web"]
+  );
+
+  assert.deepEqual(
+    parsePastedUriValues(
+      "https://app.example.com/callback?return=https://one.example,https://two.example"
+    ),
+    [
+      "https://app.example.com/callback?return=https://one.example,https://two.example",
+    ]
   );
 
   assert.deepEqual(
@@ -124,4 +147,21 @@ test("request access page submits uri arrays with callbackUrl compatibility", ()
   assert.match(page, /callbackUrl: redirectUris\[0\]/);
   assert.match(page, /redirect_uris: redirectUris/);
   assert.match(page, /post_logout_redirect_uris: postLogoutRedirectUris/);
+});
+
+test("request access page cleans single pasted uri rows", () => {
+  const page = read("src", "pages", "request-access.js");
+
+  assert.match(page, /pastedValues\.length === 1/);
+  assert.match(page, /setValue\(`\$\{fieldName\}\.\$\{index\}\.value`, pastedValues\[0\]/);
+});
+
+test("request access page uses clearer add uri button copy", () => {
+  const page = read("src", "pages", "request-access.js");
+  const styles = read("src", "pages", "request-access.module.css");
+
+  assert.match(page, /Add another redirect URI/);
+  assert.match(page, /Add another post-logout URI/);
+  assert.match(page, /uriHelpText/);
+  assert.match(styles, /\.uriHelpText/);
 });

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -193,3 +193,12 @@ test("request access page uses fieldset legends for uri groups", () => {
   assert.match(styles, /\.uriFieldset/);
   assert.match(styles, /\.uriLegend/);
 });
+
+test("client setup docs point to request access form without manual request text", () => {
+  const doc = read("docs", "tutorials", "oidc", "client-setup.mdx");
+
+  assert.match(doc, /What The Request Access Form Asks For/);
+  assert.match(doc, /Use \[Request Access\]\(\/request-access\) to submit these details/);
+  assert.match(doc, /add each URL in its own row/);
+  assert.doesNotMatch(doc, /Please provision our Quran Foundation OAuth2 client/);
+});

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -56,6 +56,28 @@ test("request access sanitizer preserves new uri arrays and dedupes values", () 
   ]);
 });
 
+test("request access sanitizer preserves commas inside single row uri values", () => {
+  const sanitized = sanitizeFormValues({
+    redirectUris: [
+      { value: "https://app.example.com/callback?aud=mobile,web" },
+    ],
+    postLogoutRedirectUris: [
+      { value: "https://app.example.com/logout?next=/one,/two" },
+    ],
+  });
+
+  assert.equal(
+    sanitized.callbackUrl,
+    "https://app.example.com/callback?aud=mobile,web"
+  );
+  assert.deepEqual(sanitized.redirectUris, [
+    { value: "https://app.example.com/callback?aud=mobile,web" },
+  ]);
+  assert.deepEqual(sanitized.postLogoutRedirectUris, [
+    { value: "https://app.example.com/logout?next=/one,/two" },
+  ]);
+});
+
 test("request access paste parser splits common multi-uri snippets", () => {
   assert.deepEqual(
     parsePastedUriValues(
@@ -66,9 +88,33 @@ test("request access paste parser splits common multi-uri snippets", () => {
 
   assert.deepEqual(
     parsePastedUriValues(
+      '"https://app.example.com/callback", "http://localhost:3000/callback"'
+    ),
+    ["https://app.example.com/callback", "http://localhost:3000/callback"]
+  );
+
+  assert.deepEqual(
+    parsePastedUriValues(
       '["https://app.example.com/logout", "http://localhost:3000/logout"]'
     ),
     ["https://app.example.com/logout", "http://localhost:3000/logout"]
+  );
+});
+
+test("request access paste parser preserves commas inside a single uri", () => {
+  assert.deepEqual(
+    parsePastedUriValues("https://app.example.com/callback?aud=mobile,web"),
+    ["https://app.example.com/callback?aud=mobile,web"]
+  );
+
+  assert.deepEqual(
+    parsePastedUriValues(
+      '["https://app.example.com/callback?aud=mobile,web", "http://localhost:3000/callback"]'
+    ),
+    [
+      "https://app.example.com/callback?aud=mobile,web",
+      "http://localhost:3000/callback",
+    ]
   );
 });
 

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -1,0 +1,81 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  parsePastedUriValues,
+  sanitizeFormValues,
+} = require("../src/pages/request-access-utils.cjs");
+
+const read = (...segments) =>
+  fs.readFileSync(path.join(__dirname, "..", ...segments), "utf-8");
+
+test("request access sanitizer migrates legacy callbackUrl session data", () => {
+  const sanitized = sanitizeFormValues({
+    appName: "Test App",
+    email: "dev@example.com",
+    callbackUrl: " https://app.example.com/callback ",
+    postLogoutRedirectUris: " https://app.example.com/logout ",
+    agreementsAccepted: true,
+  });
+
+  assert.equal(sanitized.callbackUrl, "https://app.example.com/callback");
+  assert.deepEqual(sanitized.redirectUris, [
+    { value: "https://app.example.com/callback" },
+  ]);
+  assert.deepEqual(sanitized.postLogoutRedirectUris, [
+    { value: "https://app.example.com/logout" },
+  ]);
+  assert.equal(sanitized.agreementsAccepted, true);
+});
+
+test("request access sanitizer preserves new uri arrays and dedupes values", () => {
+  const sanitized = sanitizeFormValues({
+    redirectUris: [
+      { value: "https://app.example.com/callback" },
+      { value: "" },
+      { value: "https://app.example.com/callback" },
+      { value: "http://localhost:3000/callback" },
+    ],
+    post_logout_redirect_uris: [
+      "https://app.example.com/logout",
+      "https://app.example.com/logout",
+      "http://localhost:3000/logout",
+    ],
+  });
+
+  assert.equal(sanitized.callbackUrl, "https://app.example.com/callback");
+  assert.deepEqual(sanitized.redirectUris, [
+    { value: "https://app.example.com/callback" },
+    { value: "http://localhost:3000/callback" },
+  ]);
+  assert.deepEqual(sanitized.postLogoutRedirectUris, [
+    { value: "https://app.example.com/logout" },
+    { value: "http://localhost:3000/logout" },
+  ]);
+});
+
+test("request access paste parser splits common multi-uri snippets", () => {
+  assert.deepEqual(
+    parsePastedUriValues(
+      '"https://app.example.com/callback",\n"http://localhost:3000/callback"'
+    ),
+    ["https://app.example.com/callback", "http://localhost:3000/callback"]
+  );
+
+  assert.deepEqual(
+    parsePastedUriValues(
+      '["https://app.example.com/logout", "http://localhost:3000/logout"]'
+    ),
+    ["https://app.example.com/logout", "http://localhost:3000/logout"]
+  );
+});
+
+test("request access page submits uri arrays with callbackUrl compatibility", () => {
+  const page = read("src", "pages", "request-access.js");
+
+  assert.match(page, /callbackUrl: redirectUris\[0\]/);
+  assert.match(page, /redirect_uris: redirectUris/);
+  assert.match(page, /post_logout_redirect_uris: postLogoutRedirectUris/);
+});

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -144,9 +144,16 @@ test("request access paste parser preserves commas inside a single uri", () => {
 test("request access page submits uri arrays with callbackUrl compatibility", () => {
   const page = read("src", "pages", "request-access.js");
 
-  assert.match(page, /callbackUrl: redirectUris\[0\]/);
-  assert.match(page, /redirect_uris: redirectUris/);
-  assert.match(page, /post_logout_redirect_uris: postLogoutRedirectUris/);
+  assert.match(
+    page,
+    /if \(redirectUris\.length\) \{[\s\S]*payload\.callbackUrl = redirectUris\[0\];[\s\S]*payload\.redirect_uris = redirectUris;[\s\S]*\}/
+  );
+  assert.match(
+    page,
+    /if \(postLogoutRedirectUris\.length\) \{[\s\S]*payload\.post_logout_redirect_uris = postLogoutRedirectUris;[\s\S]*\}/
+  );
+  assert.doesNotMatch(page, /redirect_uris: redirectUris/);
+  assert.doesNotMatch(page, /post_logout_redirect_uris: postLogoutRedirectUris/);
 });
 
 test("request access page cleans single pasted uri rows", () => {


### PR DESCRIPTION
## Summary
- replace the singular Redirect URI and Post-logout Redirect URI inputs with repeatable rows
- split pasted JSON arrays, newline lists, and comma-separated docs snippets into separate URI rows
- submit redirect_uris and post_logout_redirect_uris as arrays while keeping callbackUrl as the first redirect URI
- update OIDC client setup docs to tell developers to enter one URI per row

Depends on quran/qf-form-handler#14. Please merge the backend support first so production submissions can accept array payloads.

## Test plan
- yarn test
- yarn typecheck
- node --test tests/request-access-form.test.cjs

Note: yarn build was not run because this repo currently has unrelated dirty generated API docs in the original worktree and the build script runs yarn gen-all.