### PR TITLE
Clarify redirect URI environment examples

### DIFF
--- a/src/pages/request-access-utils.cjs
+++ b/src/pages/request-access-utils.cjs
@@ -2,18 +2,23 @@ const URI_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^\s"',\]]+/gi;
 const QUOTED_URI_SEPARATOR_PATTERN = /["']\s*,\s*["']/;
 const URI_LIST_SEPARATOR_PATTERN = /,\s*[a-z][a-z0-9+.-]*:\/\//i;
 
+const DEFAULT_URI_FIELD_COUNT = 3;
+
 const createEmptyUriField = () => ({ value: '' });
+
+const createDefaultUriFields = () =>
+    Array.from({ length: DEFAULT_URI_FIELD_COUNT }, () => createEmptyUriField());
 
 const createDefaultFormValues = () => ({
     appName: '',
     email: '',
     callbackUrl: '',
-    redirectUris: [createEmptyUriField()],
+    redirectUris: createDefaultUriFields(),
     logoUri: '',
     clientUri: '',
     policyUri: '',
     tosUri: '',
-    postLogoutRedirectUris: [createEmptyUriField()],
+    postLogoutRedirectUris: createDefaultUriFields(),
     agreementsAccepted: false,
 });
 
@@ -168,7 +173,7 @@ const normalizeLegacyUriList = (value) =>
 
 const toUriFields = (value, parseLegacyValue = false) => {
     const uris = parseLegacyValue ? normalizeLegacyUriList(value) : normalizeUriList(value);
-    return uris.length ? uris.map((uri) => ({ value: uri })) : [createEmptyUriField()];
+    return uris.length ? uris.map((uri) => ({ value: uri })) : createDefaultUriFields();
 };
 
 function sanitizeFormValues(values) {
@@ -238,6 +243,7 @@ const validateSingleUri = (value) => {
 module.exports = {
     createDefaultFormValues,
     createEmptyUriField,
+    createDefaultUriFields,
     dedupeUriValues,
     isEmptyFormValues,
     normalizeOptionalValue,

--- a/src/pages/request-access.js
+++ b/src/pages/request-access.js
@@ -336,9 +336,16 @@ export default function RequestAccess() {
                                 >
                                     Add another redirect URI
                                 </button>
-                                <small className={clsx('text-muted', styles.uriHelpText)}>
-                                    OAuth callback URLs. Add each callback URL in its own row.
-                                </small>
+                                <div className={clsx('text-muted', styles.uriHelpText)}>
+                                    <p>
+                                        Add every callback URL your app will use, one per row.
+                                    </p>
+                                    <ul className={styles.uriExamples}>
+                                        <li>Local development: http://localhost:3000/callback</li>
+                                        <li>Staging or preview: https://your-app-staging.vercel.app/callback</li>
+                                        <li>Production: https://your-app.com/callback</li>
+                                    </ul>
+                                </div>
                             </fieldset>
 
                             <div className="margin-bottom--md">
@@ -458,10 +465,18 @@ export default function RequestAccess() {
                                 >
                                     Add another post-logout URI
                                 </button>
-                                <small className={clsx('text-muted', styles.uriHelpText)}>
-                                    Optional. Each post-logout URI must match the scheme, domain,
-                                    and port of one redirect URI.
-                                </small>
+                                <div className={clsx('text-muted', styles.uriHelpText)}>
+                                    <p>
+                                        Add every URL users may return to after logout, one per row.
+                                        Each one must match the scheme, domain, and port of one
+                                        redirect URI.
+                                    </p>
+                                    <ul className={styles.uriExamples}>
+                                        <li>Local development: http://localhost:3000</li>
+                                        <li>Staging or preview: https://your-app-staging.vercel.app</li>
+                                        <li>Production: https://your-app.com</li>
+                                    </ul>
+                                </div>
                             </fieldset>
 
                             <div className="margin-bottom--md">

--- a/src/pages/request-access.js
+++ b/src/pages/request-access.js
@@ -12,6 +12,18 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import requestAccessUtils from './request-access-utils.cjs';
 
 const REQUEST_ACCESS_FORM_STORAGE_KEY = 'qf:request-access-form:v1';
+const REDIRECT_URI_PLACEHOLDERS = [
+    'http://localhost:3000/callback',
+    'https://your-app-staging.vercel.app/callback',
+    'https://your-app.com/callback',
+];
+const POST_LOGOUT_REDIRECT_URI_PLACEHOLDERS = [
+    'http://localhost:3000',
+    'https://your-app-staging.vercel.app',
+    'https://your-app.com',
+];
+const getUriPlaceholder = (placeholders, index) =>
+    placeholders[index] || placeholders[placeholders.length - 1];
 const {
     createDefaultFormValues,
     createEmptyUriField,
@@ -281,6 +293,12 @@ export default function RequestAccess() {
                                 <legend className={clsx('form-label', styles.uriLegend)}>
                                     Redirect URIs
                                 </legend>
+                                <div className={clsx('text-muted', styles.uriHelpText)}>
+                                    <p>
+                                        Add every callback URL your app will use, such as local
+                                        development, staging/preview, and production.
+                                    </p>
+                                </div>
                                 <div className={styles.uriList}>
                                     {redirectUriFields.map((field, index) => {
                                         const fieldError = errors.redirectUris?.[index]?.value;
@@ -291,7 +309,10 @@ export default function RequestAccess() {
                                                         type="url"
                                                         id={`redirectUris-${index}`}
                                                         className={`form-input ${fieldError ? 'form-input-error' : ''}`}
-                                                        placeholder="https://your-app.com/callback"
+                                                        placeholder={getUriPlaceholder(
+                                                            REDIRECT_URI_PLACEHOLDERS,
+                                                            index
+                                                        )}
                                                         aria-label={`Redirect URI ${index + 1}`}
                                                         {...register(`redirectUris.${index}.value`, {
                                                             validate: validateSingleUri,
@@ -336,16 +357,6 @@ export default function RequestAccess() {
                                 >
                                     Add another redirect URI
                                 </button>
-                                <div className={clsx('text-muted', styles.uriHelpText)}>
-                                    <p>
-                                        Add every callback URL your app will use, one per row.
-                                    </p>
-                                    <ul className={styles.uriExamples}>
-                                        <li>Local development: http://localhost:3000/callback</li>
-                                        <li>Staging or preview: https://your-app-staging.vercel.app/callback</li>
-                                        <li>Production: https://your-app.com/callback</li>
-                                    </ul>
-                                </div>
                             </fieldset>
 
                             <div className="margin-bottom--md">
@@ -404,6 +415,14 @@ export default function RequestAccess() {
                                 <legend className={clsx('form-label', styles.uriLegend)}>
                                     Post-logout Redirect URIs
                                 </legend>
+                                <div className={clsx('text-muted', styles.uriHelpText)}>
+                                    <p>
+                                        Optional. Add every URL users may return to after logout,
+                                        such as local development, staging/preview, and production.
+                                        Each one must match the scheme, domain, and port of one
+                                        redirect URI.
+                                    </p>
+                                </div>
                                 <div className={styles.uriList}>
                                     {postLogoutRedirectUriFields.map((field, index) => {
                                         const fieldError =
@@ -415,7 +434,10 @@ export default function RequestAccess() {
                                                         type="url"
                                                         id={`postLogoutRedirectUris-${index}`}
                                                         className={`form-input ${fieldError ? 'form-input-error' : ''}`}
-                                                        placeholder="https://your-app.com/"
+                                                        placeholder={getUriPlaceholder(
+                                                            POST_LOGOUT_REDIRECT_URI_PLACEHOLDERS,
+                                                            index
+                                                        )}
                                                         aria-label={`Post-logout Redirect URI ${index + 1}`}
                                                         {...register(
                                                             `postLogoutRedirectUris.${index}.value`,
@@ -465,18 +487,6 @@ export default function RequestAccess() {
                                 >
                                     Add another post-logout URI
                                 </button>
-                                <div className={clsx('text-muted', styles.uriHelpText)}>
-                                    <p>
-                                        Add every URL users may return to after logout, one per row.
-                                        Each one must match the scheme, domain, and port of one
-                                        redirect URI.
-                                    </p>
-                                    <ul className={styles.uriExamples}>
-                                        <li>Local development: http://localhost:3000</li>
-                                        <li>Staging or preview: https://your-app-staging.vercel.app</li>
-                                        <li>Production: https://your-app.com</li>
-                                    </ul>
-                                </div>
                             </fieldset>
 
                             <div className="margin-bottom--md">

--- a/src/pages/request-access.module.css
+++ b/src/pages/request-access.module.css
@@ -145,6 +145,19 @@
   margin-top: 0.5rem;
 }
 
+.uriHelpText p {
+  margin: 0;
+}
+
+.uriExamples {
+  margin: 0.25rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.uriExamples li {
+  margin: 0.1rem 0;
+}
+
 @media (max-width: 480px) {
   .uriRow {
     align-items: stretch;

--- a/src/pages/request-access.module.css
+++ b/src/pages/request-access.module.css
@@ -142,20 +142,13 @@
 
 .uriHelpText {
   display: block;
-  margin-top: 0.5rem;
+  font-size: var(--ifm-font-size-small, 0.875rem);
+  line-height: 1.45;
+  margin-bottom: 0.5rem;
 }
 
 .uriHelpText p {
   margin: 0;
-}
-
-.uriExamples {
-  margin: 0.25rem 0 0;
-  padding-left: 1.1rem;
-}
-
-.uriExamples li {
-  margin: 0.1rem 0;
 }
 
 @media (max-width: 480px) {

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -189,8 +189,9 @@ test("request access page uses clearer add uri button copy", () => {
   assert.match(page, /http:\/\/localhost:3000\/callback/);
   assert.match(page, /https:\/\/your-app-staging\.vercel\.app\/callback/);
   assert.match(page, /https:\/\/your-app\.com\/callback/);
-  assert.match(page, /http:\/\/localhost:3000/);
-  assert.match(page, /https:\/\/your-app-staging\.vercel\.app/);
+  assert.match(page, /'http:\/\/localhost:3000'/);
+  assert.match(page, /'https:\/\/your-app-staging\.vercel\.app'/);
+  assert.match(page, /'https:\/\/your-app\.com'/);
   assert.match(page, /Optional\. Add every URL users may return to after logout/);
   assert.match(page, /scheme, domain, and port/);
   assert.match(styles, /\.uriHelpText/);

--- a/tests/request-access-form.test.cjs
+++ b/tests/request-access-form.test.cjs
@@ -4,12 +4,28 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const {
+  createDefaultFormValues,
   parsePastedUriValues,
   sanitizeFormValues,
 } = require("../src/pages/request-access-utils.cjs");
 
 const read = (...segments) =>
   fs.readFileSync(path.join(__dirname, "..", ...segments), "utf-8");
+
+test("request access defaults show three blank uri rows", () => {
+  const defaults = createDefaultFormValues();
+
+  assert.deepEqual(defaults.redirectUris, [
+    { value: "" },
+    { value: "" },
+    { value: "" },
+  ]);
+  assert.deepEqual(defaults.postLogoutRedirectUris, [
+    { value: "" },
+    { value: "" },
+    { value: "" },
+  ]);
+});
 
 test("request access sanitizer migrates legacy callbackUrl session data", () => {
   const sanitized = sanitizeFormValues({
@@ -170,7 +186,15 @@ test("request access page uses clearer add uri button copy", () => {
   assert.match(page, /Add another redirect URI/);
   assert.match(page, /Add another post-logout URI/);
   assert.match(page, /uriHelpText/);
+  assert.match(page, /http:\/\/localhost:3000\/callback/);
+  assert.match(page, /https:\/\/your-app-staging\.vercel\.app\/callback/);
+  assert.match(page, /https:\/\/your-app\.com\/callback/);
+  assert.match(page, /http:\/\/localhost:3000/);
+  assert.match(page, /https:\/\/your-app-staging\.vercel\.app/);
+  assert.match(page, /Optional\. Add every URL users may return to after logout/);
+  assert.match(page, /scheme, domain, and port/);
   assert.match(styles, /\.uriHelpText/);
+  assert.match(styles, /font-size: var\(--ifm-font-size-small, 0\.875rem\)/);
 });
 
 test("request access page uses fieldset legends for uri groups", () => {


### PR DESCRIPTION
## Summary
- Show three blank URI rows by default for redirect and post-logout URI inputs
- Use URL-only placeholders for local development, staging/preview, and production examples
- Keep compact helper text, including the optional post-logout note and scheme/domain/port requirement

## Verification
- `node --test tests/request-access-form.test.cjs`
- `git diff --check -- src/pages/request-access-utils.cjs src/pages/request-access.js src/pages/request-access.module.css tests/request-access-form.test.cjs`