### PR TITLE
docs: document QuranReflect post SDK usage

### DIFF
--- a/docs/sdk/javascript/apis-by-runtime.mdx
+++ b/docs/sdk/javascript/apis-by-runtime.mdx
@@ -22,7 +22,10 @@ Minimal import: `@quranjs/api/server` or `@quranjs/api/public`.
 | Content answers | Yes | No |
 | Search | Yes | No |
 | User APIs with existing session | Yes | Yes |
+| QuranReflect post mutations | Yes | Yes, with an existing user session |
 | OAuth2 authorize URL | Yes | Yes |
 | OAuth2 code exchange for confidential clients | Yes | No |
 | OAuth2 code exchange for approved public clients | No need | Yes |
 | OAuth2 token introspection | Yes | No |
+
+For the post payload shape, see [QuranReflect Posts](/docs/sdk/javascript/quranreflect-posts).

--- a/docs/sdk/javascript/common-errors.mdx
+++ b/docs/sdk/javascript/common-errors.mdx
@@ -22,3 +22,4 @@ Minimal import: Depends on the error.
 | `This OAuth2 exchange requires a backend` | Your client is confidential | Exchange the code on the backend |
 | `This operation requires a user session` | You called a user API with no access token | Sign in first or inject a session |
 | `401 Unauthorized` | Token is missing, expired, or wrong for that API | Check token type, scopes, and environment |
+| QuranReflect create post sends a raw string body | Older generated calls used the operation wrapper and `{ body: "..." }` was the HTTP body | Use the typed helper payload or `{ body: { post: ... } }`; see [QuranReflect Posts](/docs/sdk/javascript/quranreflect-posts) |

--- a/docs/sdk/javascript/index.mdx
+++ b/docs/sdk/javascript/index.mdx
@@ -244,6 +244,7 @@ The copyable prompt above is published as `QF_NPX_STARTER_PROMPT_V1`:
 - [Server Quickstart](/docs/sdk/javascript/server-quickstart)
 - [Public Quickstart](/docs/sdk/javascript/public-quickstart)
 - [Full-Stack Quickstart](/docs/sdk/javascript/full-stack)
+- [QuranReflect Posts](/docs/sdk/javascript/quranreflect-posts)
 - [Common Errors](/docs/sdk/javascript/common-errors)
 - [Migration Cheat Sheet](/docs/sdk/javascript/migration-cheat-sheet)
 - [Answers API](/docs/sdk/javascript/answers)

--- a/docs/sdk/javascript/public-quickstart.mdx
+++ b/docs/sdk/javascript/public-quickstart.mdx
@@ -48,6 +48,10 @@ const client = createPublicClient({
 const collections = await client.auth.v1.collections.list();
 ```
 
+With an existing user session and the `post` scope, the public client can use
+the same QuranReflect post helper shape documented in
+[QuranReflect Posts](/docs/sdk/javascript/quranreflect-posts).
+
 ## Common Mistakes
 
 - Putting `client_secret` in frontend code.

--- a/docs/sdk/javascript/quranreflect-posts.mdx
+++ b/docs/sdk/javascript/quranreflect-posts.mdx
@@ -57,12 +57,18 @@ The SDK wraps the payload for the REST endpoint as:
 }
 ```
 
-The typed helper does not synthesize advanced post fields. For ordinary public or
-draft reflections, pass `body`, `draft`, `mentions`, and `references`. Advanced
-fields such as `roomId`, `roomPostStatus`, `postAsAuthorId`, and `publishedAt`
-are optional passthrough fields for room posts, authorized author posting, or
-scheduled/custom publish timing. If you omit them, the SDK leaves them out and
-the API applies its server-side defaults and authorization rules.
+The minimal example above is runnable with the typed helper. The generated REST
+reference currently marks some advanced fields as required, but the API accepts
+omitting them for ordinary public or draft reflections:
+
+- `roomPostStatus` defaults to public visibility.
+- `publishedAt` is set by the API for non-draft posts and omitted for drafts.
+- `roomId` is only needed for room posts.
+- `postAsAuthorId` is only needed for approved post-as-author flows.
+
+The SDK does not synthesize those advanced fields. If you provide `roomId`,
+`roomPostStatus`, `postAsAuthorId`, or `publishedAt`, the helper passes them
+through inside `post` and the API applies its authorization rules.
 
 ## Edit and Read a Post
 

--- a/docs/sdk/javascript/quranreflect-posts.mdx
+++ b/docs/sdk/javascript/quranreflect-posts.mdx
@@ -57,6 +57,13 @@ The SDK wraps the payload for the REST endpoint as:
 }
 ```
 
+The typed helper does not synthesize advanced post fields. For ordinary public or
+draft reflections, pass `body`, `draft`, `mentions`, and `references`. Advanced
+fields such as `roomId`, `roomPostStatus`, `postAsAuthorId`, and `publishedAt`
+are optional passthrough fields for room posts, authorized author posting, or
+scheduled/custom publish timing. If you omit them, the SDK leaves them out and
+the API applies its server-side defaults and authorization rules.
+
 ## Edit and Read a Post
 
 ```ts
@@ -69,8 +76,9 @@ const post = await client.quranReflect.v1.posts.get(123);
 
 ## Compatibility Shape
 
-Older generated SDK calls and advanced raw-operation calls use an operation
-request wrapper. That shape remains supported:
+This guide targets the typed QuranReflect post helper added with
+`CreateQuranReflectPostPayload`. Older SDK versions and advanced raw-operation
+calls use an operation request wrapper. That shape remains supported:
 
 ```ts
 await client.quranReflect.v1.posts.create({
@@ -102,7 +110,8 @@ await client.quranReflect.v1.raw.postsControllerCreate({
 
 ## Common Mistake
 
-Do not pass this shape to older generated SDK methods:
+Do not pass this shape to older generated SDK methods or to
+`raw.postsControllerCreate`:
 
 ```ts
 await client.quranReflect.v1.posts.create({
@@ -110,9 +119,9 @@ await client.quranReflect.v1.posts.create({
 });
 ```
 
-In older SDK versions, that sends the raw string as the HTTP request body. Use
-the typed helper payload shown above, or use the compatibility wrapper
-`{ body: { post: ... } }`.
+In those generated-operation paths, that sends the raw string as the HTTP
+request body. Use the typed helper payload shown above when your installed SDK
+exposes it, or use the compatibility wrapper `{ body: { post: ... } }`.
 
 ## Related REST Reference
 

--- a/docs/sdk/javascript/quranreflect-posts.mdx
+++ b/docs/sdk/javascript/quranreflect-posts.mdx
@@ -1,0 +1,119 @@
+---
+title: "QuranReflect Posts"
+description: "Create, edit, and read QuranReflect posts with the JavaScript SDK."
+slug: /sdk/javascript/quranreflect-posts
+sidebar_position: 15
+---
+
+# QuranReflect Posts
+
+- Purpose: Create and manage QuranReflect reflections through the SDK.
+- Use this when: You have a signed-in user session and the `post` scope.
+- Do not use this when: You only need public feed reads from Content APIs.
+- Backend required: Usually yes.
+- Allowed runtimes: Server or public runtime with an existing user session.
+- Required credentials: `client_id`; `client_secret` only on the server.
+- Minimal import: `@quranjs/api/server`.
+
+For most apps, call QuranReflect post mutations from your backend with
+`@quranjs/api/server`. Use `@quranjs/api/public` only when Quran Foundation has
+approved your client/runtime and your app already has a valid user session.
+
+The signed-in user must grant the `post` scope.
+
+## Create a Post
+
+```ts
+import { createServerClient } from "@quranjs/api/server";
+
+const client = createServerClient({
+  clientId: process.env.QF_CLIENT_ID!,
+  clientSecret: process.env.QF_CLIENT_SECRET!,
+  userSession: {
+    accessToken: "signed-in-user-access-token",
+  },
+});
+
+const response = await client.quranReflect.v1.posts.create({
+  body: "A reflection created through the SDK.",
+  draft: false,
+  mentions: [],
+  references: [{ chapterId: 1, from: 1, to: 1 }],
+});
+
+const postId = response.data?.id ?? response.post?.id;
+```
+
+The SDK wraps the payload for the REST endpoint as:
+
+```ts
+{
+  post: {
+    body: "A reflection created through the SDK.",
+    draft: false,
+    mentions: [],
+    references: [{ chapterId: 1, from: 1, to: 1 }],
+  },
+}
+```
+
+## Edit and Read a Post
+
+```ts
+await client.quranReflect.v1.posts.update(123, {
+  body: "Updated reflection text.",
+});
+
+const post = await client.quranReflect.v1.posts.get(123);
+```
+
+## Compatibility Shape
+
+Older generated SDK calls and advanced raw-operation calls use an operation
+request wrapper. That shape remains supported:
+
+```ts
+await client.quranReflect.v1.posts.create({
+  body: {
+    post: {
+      body: "A reflection created through the generated operation shape.",
+      draft: false,
+      mentions: [],
+      references: [{ chapterId: 1, from: 1, to: 1 }],
+    },
+  },
+});
+```
+
+You can always access the raw generated operation directly:
+
+```ts
+await client.quranReflect.v1.raw.postsControllerCreate({
+  body: {
+    post: {
+      body: "A reflection created through the raw operation.",
+      draft: false,
+      mentions: [],
+      references: [{ chapterId: 1, from: 1, to: 1 }],
+    },
+  },
+});
+```
+
+## Common Mistake
+
+Do not pass this shape to older generated SDK methods:
+
+```ts
+await client.quranReflect.v1.posts.create({
+  body: "A reflection body",
+});
+```
+
+In older SDK versions, that sends the raw string as the HTTP request body. Use
+the typed helper payload shown above, or use the compatibility wrapper
+`{ body: { post: ... } }`.
+
+## Related REST Reference
+
+- [Create post](/docs/user_related_apis_prelive/posts-controller-create)

--- a/docs/sdk/javascript/server-quickstart.mdx
+++ b/docs/sdk/javascript/server-quickstart.mdx
@@ -39,6 +39,8 @@ const results = await client.search.v1.query({
 });
 ```
 
+For signed-in user post mutations, see [QuranReflect Posts](/docs/sdk/javascript/quranreflect-posts).
+
 ## Common Mistake
 
 Do not import `@quranjs/api/public` from backend code unless you are explicitly testing public-client behavior. Production defaults are already built in; local maintainer testing instructions live in the SDK repo.

--- a/scripts/set-api-displayed-sidebars.js
+++ b/scripts/set-api-displayed-sidebars.js
@@ -204,6 +204,62 @@ function hasUsableSidebarLink(item, validDocIds) {
   return validDocIds.has(item.link.id);
 }
 
+function slugifySidebarLabel(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/['\u2019]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function findFirstDocId(items) {
+  for (const item of items) {
+    if (!item || typeof item !== 'object') {
+      continue;
+    }
+
+    if (item.type === 'doc' && typeof item.id === 'string') {
+      return item.id;
+    }
+
+    if (item.type === 'category' && Array.isArray(item.items)) {
+      const nestedDocId = findFirstDocId(item.items);
+
+      if (nestedDocId) {
+        return nestedDocId;
+      }
+    }
+  }
+
+  return null;
+}
+
+function inferCategoryTagLink(item, validDocIds) {
+  if (
+    item.link ||
+    typeof item.label !== 'string' ||
+    !Array.isArray(item.items)
+  ) {
+    return null;
+  }
+
+  const firstDocId = findFirstDocId(item.items);
+
+  if (!firstDocId || !firstDocId.includes('/')) {
+    return null;
+  }
+
+  const docPrefix = firstDocId.split('/').slice(0, -1).join('/');
+  const candidateId = `${docPrefix}/${slugifySidebarLabel(item.label)}`;
+
+  return validDocIds.has(candidateId)
+    ? {
+        type: 'doc',
+        id: candidateId,
+      }
+    : null;
+}
+
 function filterMissingSidebarItems(items, validDocIds) {
   return items.reduce((accumulator, item) => {
     if (!item || typeof item !== 'object') {
@@ -220,19 +276,21 @@ function filterMissingSidebarItems(items, validDocIds) {
     }
 
     if (item.type === 'category' && Array.isArray(item.items)) {
-      const filteredItems = filterMissingSidebarItems(item.items, validDocIds);
-      const hasUsableLink = hasUsableSidebarLink(item, validDocIds);
+      const inferredLink = inferCategoryTagLink(item, validDocIds);
+      const linkedItem = inferredLink ? { ...item, link: inferredLink } : item;
+      const filteredItems = filterMissingSidebarItems(linkedItem.items, validDocIds);
+      const hasUsableLink = hasUsableSidebarLink(linkedItem, validDocIds);
 
       if (!hasUsableLink && filteredItems.length === 0) {
         return accumulator;
       }
 
       const normalizedItem = {
-        ...item,
+        ...linkedItem,
         items: filteredItems,
       };
 
-      if (item.link && !hasUsableLink) {
+      if (linkedItem.link && !hasUsableLink) {
         delete normalizedItem.link;
       }
 
@@ -323,6 +381,7 @@ module.exports = {
   filterMissingSidebarItems,
   getDisplayedSidebarId,
   hasUsableSidebarLink,
+  inferCategoryTagLink,
   normalizeRubElHizbDocLabels,
   normalizeRubElHizbSidebarLabels,
   main,

--- a/scripts/set-api-displayed-sidebars.js
+++ b/scripts/set-api-displayed-sidebars.js
@@ -234,7 +234,7 @@ function findFirstDocId(items) {
   return null;
 }
 
-function inferCategoryTagLink(item, validDocIds) {
+function inferCategoryTagLink(item, tagDocIds) {
   if (
     item.link ||
     typeof item.label !== 'string' ||
@@ -252,7 +252,7 @@ function inferCategoryTagLink(item, validDocIds) {
   const docPrefix = firstDocId.split('/').slice(0, -1).join('/');
   const candidateId = `${docPrefix}/${slugifySidebarLabel(item.label)}`;
 
-  return validDocIds.has(candidateId)
+  return tagDocIds.has(candidateId)
     ? {
         type: 'doc',
         id: candidateId,
@@ -260,7 +260,7 @@ function inferCategoryTagLink(item, validDocIds) {
     : null;
 }
 
-function filterMissingSidebarItems(items, validDocIds) {
+function filterMissingSidebarItems(items, validDocIds, tagDocIds = new Set()) {
   return items.reduce((accumulator, item) => {
     if (!item || typeof item !== 'object') {
       accumulator.push(item);
@@ -276,9 +276,13 @@ function filterMissingSidebarItems(items, validDocIds) {
     }
 
     if (item.type === 'category' && Array.isArray(item.items)) {
-      const inferredLink = inferCategoryTagLink(item, validDocIds);
+      const inferredLink = inferCategoryTagLink(item, tagDocIds);
       const linkedItem = inferredLink ? { ...item, link: inferredLink } : item;
-      const filteredItems = filterMissingSidebarItems(linkedItem.items, validDocIds);
+      const filteredItems = filterMissingSidebarItems(
+        linkedItem.items,
+        validDocIds,
+        tagDocIds,
+      );
       const hasUsableLink = hasUsableSidebarLink(linkedItem, validDocIds);
 
       if (!hasUsableLink && filteredItems.length === 0) {
@@ -303,10 +307,14 @@ function filterMissingSidebarItems(items, validDocIds) {
   }, []);
 }
 
-function normalizeGeneratedSidebar(filePath, validDocIds) {
+function normalizeGeneratedSidebar(filePath, validDocIds, tagDocIds) {
   delete require.cache[require.resolve(filePath)];
   const sidebarItems = require(filePath);
-  const filteredSidebarItems = filterMissingSidebarItems(sidebarItems, validDocIds);
+  const filteredSidebarItems = filterMissingSidebarItems(
+    sidebarItems,
+    validDocIds,
+    tagDocIds,
+  );
   const dedupedSidebarItems = dedupeSidebarItems(filteredSidebarItems);
   const normalizedSidebarItems = normalizeRubElHizbSidebarLabels(dedupedSidebarItems);
   const serializedSidebar = `module.exports = ${JSON.stringify(normalizedSidebarItems)};`;
@@ -318,6 +326,7 @@ function main() {
   let updatedFiles = 0;
   let checkedFiles = 0;
   const validDocIds = new Set();
+  const tagDocIds = new Set();
 
   for (const docsDir of docsDirs) {
     if (!fs.existsSync(docsDir)) {
@@ -325,7 +334,13 @@ function main() {
     }
 
     for (const filePath of walk(docsDir)) {
-      validDocIds.add(getDocId(filePath));
+      const docId = getDocId(filePath);
+
+      validDocIds.add(docId);
+
+      if (/\.tag\.mdx$/.test(filePath)) {
+        tagDocIds.add(docId);
+      }
     }
   }
 
@@ -349,7 +364,7 @@ function main() {
 
       const originalContent = fs.readFileSync(filePath, 'utf8');
       const normalizedContent = generatedSidebarPattern.test(filePath)
-        ? normalizeGeneratedSidebar(filePath, validDocIds)
+        ? normalizeGeneratedSidebar(filePath, validDocIds, tagDocIds)
         : normalizeRubElHizbDocLabels(
             filePath,
             normalizeGeneratedLabels(originalContent, filePath),

--- a/sidebars.js
+++ b/sidebars.js
@@ -503,6 +503,7 @@ const buildSdkSidebarItems = () => [
       "sdk/javascript/answers",
       "sdk/javascript/juzs",
       "sdk/javascript/search",
+      "sdk/javascript/quranreflect-posts",
       "sdk/javascript/common-errors",
       "sdk/javascript/migration-cheat-sheet",
       "sdk/javascript/v1-migration-guide",

--- a/tests/api-sidebar-cleanup.test.cjs
+++ b/tests/api-sidebar-cleanup.test.cjs
@@ -98,6 +98,47 @@ test('keeps non-empty categories but strips invalid doc links', () => {
   );
 });
 
+test('links generated tag docs to matching sidebar categories', () => {
+  const items = [
+    {
+      type: 'category',
+      label: 'Activity Days',
+      items: [
+        {
+          type: 'doc',
+          id: 'user_related_apis_prelive/add-update-activity-day',
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(
+    filterMissingSidebarItems(
+      items,
+      new Set([
+        'user_related_apis_prelive/activity-days',
+        'user_related_apis_prelive/add-update-activity-day',
+      ]),
+    ),
+    [
+      {
+        type: 'category',
+        label: 'Activity Days',
+        link: {
+          type: 'doc',
+          id: 'user_related_apis_prelive/activity-days',
+        },
+        items: [
+          {
+            type: 'doc',
+            id: 'user_related_apis_prelive/add-update-activity-day',
+          },
+        ],
+      },
+    ],
+  );
+});
+
 test('normalizes Rub el Hizb alias labels in generated API docs', () => {
   const filePath = path.join(
     __dirname,

--- a/tests/api-sidebar-cleanup.test.cjs
+++ b/tests/api-sidebar-cleanup.test.cjs
@@ -119,6 +119,7 @@ test('links generated tag docs to matching sidebar categories', () => {
         'user_related_apis_prelive/activity-days',
         'user_related_apis_prelive/add-update-activity-day',
       ]),
+      new Set(['user_related_apis_prelive/activity-days']),
     ),
     [
       {
@@ -132,6 +133,44 @@ test('links generated tag docs to matching sidebar categories', () => {
           {
             type: 'doc',
             id: 'user_related_apis_prelive/add-update-activity-day',
+          },
+        ],
+      },
+    ],
+  );
+});
+
+test('does not infer category links from matching operation docs', () => {
+  const items = [
+    {
+      type: 'category',
+      label: 'Translations',
+      items: [
+        {
+          type: 'doc',
+          id: 'content_apis_versioned/list-ayah-translations',
+        },
+      ],
+    },
+  ];
+
+  assert.deepEqual(
+    filterMissingSidebarItems(
+      items,
+      new Set([
+        'content_apis_versioned/translations',
+        'content_apis_versioned/list-ayah-translations',
+      ]),
+      new Set(),
+    ),
+    [
+      {
+        type: 'category',
+        label: 'Translations',
+        items: [
+          {
+            type: 'doc',
+            id: 'content_apis_versioned/list-ayah-translations',
           },
         ],
       },


### PR DESCRIPTION
﻿## Summary
- add a dedicated JavaScript SDK guide for QuranReflect post create/update/get calls
- document required runtime, `post` scope, direct helper payloads, raw compatibility shape, and old generated-method pitfall
- link the new page from the SDK index, runtime pages, and common errors
- normalize generated tag sidebar links so `yarn build` remains repeatable after OpenAPI generation

## Validation
- `yarn typecheck`
- `yarn test`
- `yarn build`
