### PR TITLE
docs: add Content API response examples

### DIFF
--- a/openAPI/content/v4.json
+++ b/openAPI/content/v4.json
@@ -119,10 +119,24 @@
                     }
                   }
                 },
-                "example": {
-                  "result": {
-                    "timestamp_from": 0,
-                    "timestamp_to": 6493
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "result": {
+                        "timestamp_from": 0,
+                        "timestamp_to": 6493
+                      }
+                    }
+                  },
+                  "ayah_timestamp_range": {
+                    "summary": "Timestamp range for one ayah",
+                    "value": {
+                      "result": {
+                        "timestamp_from": 0,
+                        "timestamp_to": 6493
+                      }
+                    }
                   }
                 }
               }
@@ -317,24 +331,52 @@
                     }
                   }
                 },
-                "example": {
-                  "result": {
-                    "verse_key": "1:1",
-                    "timestamp_from": 0,
-                    "timestamp_to": 6493,
-                    "duration": -6493,
-                    "segments": [
-                      [
-                        1,
-                        0,
-                        630
-                      ],
-                      [
-                        2,
-                        650,
-                        1570
-                      ]
-                    ]
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "result": {
+                        "verse_key": "1:1",
+                        "timestamp_from": 0,
+                        "timestamp_to": 6493,
+                        "duration": -6493,
+                        "segments": [
+                          [
+                            1,
+                            0,
+                            630
+                          ],
+                          [
+                            2,
+                            650,
+                            1570
+                          ]
+                        ]
+                      }
+                    }
+                  },
+                  "timestamp_lookup_with_segments": {
+                    "summary": "Lookup timestamp with word segments",
+                    "value": {
+                      "result": {
+                        "verse_key": "1:1",
+                        "timestamp_from": 0,
+                        "timestamp_to": 6493,
+                        "duration": -6493,
+                        "segments": [
+                          [
+                            1,
+                            0,
+                            630
+                          ],
+                          [
+                            2,
+                            650,
+                            1570
+                          ]
+                        ]
+                      }
+                    }
                   }
                 }
               }
@@ -462,27 +504,118 @@
                     }
                   }
                 },
-                "example": {
-                  "chapters": [
-                    {
-                      "id": 1,
-                      "revelation_place": "makkah",
-                      "revelation_order": 5,
-                      "bismillah_pre": false,
-                      "name_simple": "Al-Fatihah",
-                      "name_complex": "Al-Fātiĥah",
-                      "name_arabic": "الفاتحة",
-                      "verses_count": 7,
-                      "pages": [
-                        1,
-                        1
-                      ],
-                      "translated_name": {
-                        "language_name": "english",
-                        "name": "The Opener"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "chapters": [
+                        {
+                          "id": 1,
+                          "revelation_place": "makkah",
+                          "revelation_order": 5,
+                          "bismillah_pre": false,
+                          "name_simple": "Al-Fatihah",
+                          "name_complex": "Al-Fātiĥah",
+                          "name_arabic": "الفاتحة",
+                          "verses_count": 7,
+                          "pages": [
+                            1,
+                            1
+                          ],
+                          "translated_name": {
+                            "language_name": "english",
+                            "name": "The Opener"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "english_catalog": {
+                    "summary": "English chapter catalog",
+                    "value": {
+                      "chapters": [
+                        {
+                          "id": 1,
+                          "revelation_place": "makkah",
+                          "revelation_order": 5,
+                          "bismillah_pre": false,
+                          "name_simple": "Al-Fatihah",
+                          "name_complex": "Al-Fātiĥah",
+                          "name_arabic": "الفاتحة",
+                          "verses_count": 7,
+                          "pages": [
+                            1,
+                            1
+                          ],
+                          "translated_name": {
+                            "language_name": "english",
+                            "name": "The Opener"
+                          }
+                        },
+                        {
+                          "id": 2,
+                          "revelation_place": "madinah",
+                          "revelation_order": 87,
+                          "bismillah_pre": true,
+                          "name_simple": "Al-Baqarah",
+                          "name_complex": "Al-Baqarah",
+                          "name_arabic": "البقرة",
+                          "verses_count": 286,
+                          "pages": [
+                            2,
+                            49
+                          ],
+                          "translated_name": {
+                            "language_name": "english",
+                            "name": "The Cow"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "arabic_translated_names": {
+                    "summary": "Arabic localized chapter names",
+                    "value": {
+                      "chapters": [
+                        {
+                          "id": 1,
+                          "revelation_place": "makkah",
+                          "revelation_order": 5,
+                          "bismillah_pre": false,
+                          "name_simple": "Al-Fatihah",
+                          "name_complex": "Al-Fātiĥah",
+                          "name_arabic": "الفاتحة",
+                          "verses_count": 7,
+                          "pages": [
+                            1,
+                            1
+                          ],
+                          "translated_name": {
+                            "language_name": "arabic",
+                            "name": "الفاتحة"
+                          }
+                        },
+                        {
+                          "id": 2,
+                          "revelation_place": "madinah",
+                          "revelation_order": 87,
+                          "bismillah_pre": true,
+                          "name_simple": "Al-Baqarah",
+                          "name_complex": "Al-Baqarah",
+                          "name_arabic": "البقرة",
+                          "verses_count": 286,
+                          "pages": [
+                            2,
+                            49
+                          ],
+                          "translated_name": {
+                            "language_name": "arabic",
+                            "name": "البقرة"
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -614,23 +747,74 @@
                     }
                   }
                 },
-                "example": {
-                  "chapter": {
-                    "id": 1,
-                    "revelation_place": "makkah",
-                    "revelation_order": 5,
-                    "bismillah_pre": false,
-                    "name_simple": "Al-Fatihah",
-                    "name_complex": "Al-Fātiĥah",
-                    "name_arabic": "الفاتحة",
-                    "verses_count": 7,
-                    "pages": [
-                      1,
-                      1
-                    ],
-                    "translated_name": {
-                      "language_name": "english",
-                      "name": "The Opener"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "chapter": {
+                        "id": 1,
+                        "revelation_place": "makkah",
+                        "revelation_order": 5,
+                        "bismillah_pre": false,
+                        "name_simple": "Al-Fatihah",
+                        "name_complex": "Al-Fātiĥah",
+                        "name_arabic": "الفاتحة",
+                        "verses_count": 7,
+                        "pages": [
+                          1,
+                          1
+                        ],
+                        "translated_name": {
+                          "language_name": "english",
+                          "name": "The Opener"
+                        }
+                      }
+                    }
+                  },
+                  "makkah_chapter": {
+                    "summary": "Makkah chapter",
+                    "value": {
+                      "chapter": {
+                        "id": 1,
+                        "revelation_place": "makkah",
+                        "revelation_order": 5,
+                        "bismillah_pre": false,
+                        "name_simple": "Al-Fatihah",
+                        "name_complex": "Al-Fātiĥah",
+                        "name_arabic": "الفاتحة",
+                        "verses_count": 7,
+                        "pages": [
+                          1,
+                          1
+                        ],
+                        "translated_name": {
+                          "language_name": "english",
+                          "name": "The Opener"
+                        }
+                      }
+                    }
+                  },
+                  "madinah_chapter": {
+                    "summary": "Madinah chapter",
+                    "value": {
+                      "chapter": {
+                        "id": 2,
+                        "revelation_place": "madinah",
+                        "revelation_order": 87,
+                        "bismillah_pre": true,
+                        "name_simple": "Al-Baqarah",
+                        "name_complex": "Al-Baqarah",
+                        "name_arabic": "البقرة",
+                        "verses_count": 286,
+                        "pages": [
+                          2,
+                          49
+                        ],
+                        "translated_name": {
+                          "language_name": "english",
+                          "name": "The Cow"
+                        }
+                      }
                     }
                   }
                 }
@@ -807,29 +991,68 @@
                     }
                   }
                 },
-                "example": {
-                  "chapter_info": {
-                    "id": 1,
-                    "chapter_id": 1,
-                    "language_name": "english",
-                    "short_text": "This Surah is named Al-Fatihah because of its subject-matter. Fatihah is that which opens a subject or a book or any other thing. In other words, Al-Fatihah is a sort of preface.",
-                    "source": "Sayyid Abul Ala Maududi - Tafhim al-Qur'an - The Meaning of the Quran",
-                    "text": "<h2>Name</h2>\r\n<p>This Surah is named Al-Fatihah because of its subject-matter. Fatihah is that which opens a subject or a book or any other thing. In other words, Al-Fatihah is a sort of preface.</p>\r\n<h2>Period of Revelation</h2>...",
-                    "resource_id": 58
-                  },
-                  "resources": [
-                    {
-                      "id": 58,
-                      "name": "Chapter Info",
-                      "author_name": "Sayyid Abul Ala Maududi",
-                      "slug": "",
-                      "language_name": "english",
-                      "translated_name": {
-                        "name": "Chapter Info",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "chapter_info": {
+                        "id": 1,
+                        "chapter_id": 1,
+                        "language_name": "english",
+                        "short_text": "This Surah is named Al-Fatihah because of its subject-matter. Fatihah is that which opens a subject or a book or any other thing. In other words, Al-Fatihah is a sort of preface.",
+                        "source": "Sayyid Abul Ala Maududi - Tafhim al-Qur'an - The Meaning of the Quran",
+                        "text": "<h2>Name</h2>\r\n<p>This Surah is named Al-Fatihah because of its subject-matter. Fatihah is that which opens a subject or a book or any other thing. In other words, Al-Fatihah is a sort of preface.</p>\r\n<h2>Period of Revelation</h2>...",
+                        "resource_id": 58
+                      },
+                      "resources": [
+                        {
+                          "id": 58,
+                          "name": "Chapter Info",
+                          "author_name": "Sayyid Abul Ala Maududi",
+                          "slug": "",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Chapter Info",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "resolved_with_resources": {
+                    "summary": "Resolved chapter info with resource list",
+                    "value": {
+                      "chapter_info": {
+                        "id": 1,
+                        "chapter_id": 1,
+                        "language_name": "english",
+                        "short_text": "This Surah is named Al-Fatihah because it opens the Book.",
+                        "source": "Sayyid Abul Ala Maududi - Tafhim al-Qur'an - The Meaning of the Quran",
+                        "text": "<h2>Name</h2><p>This Surah is named Al-Fatihah because it opens the Book.</p>",
+                        "resource_id": 58
+                      },
+                      "resources": [
+                        {
+                          "id": 58,
+                          "name": "Chapter Info",
+                          "author_name": "Sayyid Abul Ala Maududi",
+                          "slug": "chapter-info-maududi",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Chapter Info",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "no_matching_resource": {
+                    "summary": "No approved chapter info for selected resource",
+                    "value": {
+                      "chapter_info": null,
+                      "resources": []
+                    }
+                  }
                 }
               }
             }
@@ -955,36 +1178,86 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-references-by-ayah-response"
                 },
-                "example": {
-                  "verse_key": "12:12",
-                  "verse_number": 12,
-                  "chapter_number": 12,
-                  "language": "en",
-                  "direction": "ltr",
-                  "hadith_references": [
-                    {
-                      "id": 10,
-                      "collection": "bukhari",
-                      "hadith_number": "1",
-                      "our_hadith_number": 1,
-                      "arabic_urn": 111,
-                      "english_urn": 211,
-                      "surah_number": 12,
-                      "ayah_start_number": 11,
-                      "ayah_end_number": 12
-                    },
-                    {
-                      "id": 11,
-                      "collection": "muslim",
-                      "hadith_number": "3",
-                      "our_hadith_number": 1,
-                      "arabic_urn": 113,
-                      "english_urn": 213,
-                      "surah_number": 12,
-                      "ayah_start_number": 12,
-                      "ayah_end_number": 14
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verse_key": "12:12",
+                      "verse_number": 12,
+                      "chapter_number": 12,
+                      "language": "en",
+                      "direction": "ltr",
+                      "hadith_references": [
+                        {
+                          "id": 10,
+                          "collection": "bukhari",
+                          "hadith_number": "1",
+                          "our_hadith_number": 1,
+                          "arabic_urn": 111,
+                          "english_urn": 211,
+                          "surah_number": 12,
+                          "ayah_start_number": 11,
+                          "ayah_end_number": 12
+                        },
+                        {
+                          "id": 11,
+                          "collection": "muslim",
+                          "hadith_number": "3",
+                          "our_hadith_number": 1,
+                          "arabic_urn": 113,
+                          "english_urn": 213,
+                          "surah_number": 12,
+                          "ayah_start_number": 12,
+                          "ayah_end_number": 14
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "references_found": {
+                    "summary": "Ayah with hadith references",
+                    "value": {
+                      "verse_key": "12:12",
+                      "verse_number": 12,
+                      "chapter_number": 12,
+                      "language": "en",
+                      "direction": "ltr",
+                      "hadith_references": [
+                        {
+                          "id": 10,
+                          "collection": "bukhari",
+                          "hadith_number": "1",
+                          "our_hadith_number": 1,
+                          "arabic_urn": 111,
+                          "english_urn": 211,
+                          "surah_number": 12,
+                          "ayah_start_number": 11,
+                          "ayah_end_number": 12
+                        },
+                        {
+                          "id": 11,
+                          "collection": "muslim",
+                          "hadith_number": "3",
+                          "our_hadith_number": 1,
+                          "arabic_urn": 113,
+                          "english_urn": 213,
+                          "surah_number": 12,
+                          "ayah_start_number": 12,
+                          "ayah_end_number": 14
+                        }
+                      ]
+                    }
+                  },
+                  "no_references": {
+                    "summary": "Ayah with no hadith references",
+                    "value": {
+                      "verse_key": "1:1",
+                      "verse_number": 1,
+                      "chapter_number": 1,
+                      "language": "en",
+                      "direction": "ltr",
+                      "hadith_references": []
+                    }
+                  }
                 }
               }
             }
@@ -996,15 +1269,20 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 400,
-                  "error": {
-                    "code": "INVALID_PARAMETER",
-                    "message": "Invalid ayah_key format. Expected format: chapter:verse (e.g., 12:12)",
-                    "details": {
-                      "parameter": "ayah_key",
-                      "provided": "12-12",
-                      "expected": "12:12"
+                "examples": {
+                  "invalid_request": {
+                    "summary": "Invalid request",
+                    "value": {
+                      "status": 400,
+                      "error": {
+                        "code": "INVALID_PARAMETER",
+                        "message": "Invalid ayah_key format. Expected format: chapter:verse (e.g., 12:12)",
+                        "details": {
+                          "parameter": "ayah_key",
+                          "provided": "12-12",
+                          "expected": "12:12"
+                        }
+                      }
                     }
                   }
                 }
@@ -1024,12 +1302,17 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 404,
-                  "error": {
-                    "code": "NOT_FOUND",
-                    "message": "Verse 999:999 not found",
-                    "details": {}
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "status": 404,
+                      "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Verse 999:999 not found",
+                        "details": {}
+                      }
+                    }
                   }
                 }
               }
@@ -1111,55 +1394,124 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-by-ayah-response"
                 },
-                "example": {
-                  "hadiths": [
-                    {
-                      "urn": 201,
-                      "collection": "bukhari",
-                      "bookNumber": "1",
-                      "chapterId": "1",
-                      "hadithNumber": "1",
-                      "name": "Sahih al-Bukhari",
-                      "hadith": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "hadiths": [
                         {
-                          "lang": "en",
-                          "chapterNumber": "1",
-                          "chapterTitle": "Revelation",
-                          "body": "Narrated Umar bin Al-Khattab:...",
-                          "urn": 31,
-                          "grades": [
+                          "urn": 201,
+                          "collection": "bukhari",
+                          "bookNumber": "1",
+                          "chapterId": "1",
+                          "hadithNumber": "1",
+                          "name": "Sahih al-Bukhari",
+                          "hadith": [
                             {
-                              "graded_by": "Ahmad Muhammad Shakir",
-                              "grade": "Sahih"
+                              "lang": "en",
+                              "chapterNumber": "1",
+                              "chapterTitle": "Revelation",
+                              "body": "Narrated Umar bin Al-Khattab:...",
+                              "urn": 31,
+                              "grades": [
+                                {
+                                  "graded_by": "Ahmad Muhammad Shakir",
+                                  "grade": "Sahih"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "urn": 202,
+                          "collection": "muslim",
+                          "bookNumber": "1",
+                          "chapterId": "2",
+                          "hadithNumber": "1",
+                          "name": "Sahih Muslim",
+                          "hadith": [
+                            {
+                              "lang": "en",
+                              "chapterNumber": "2",
+                              "chapterTitle": "Faith",
+                              "body": "Narrated Abu Huraira:...",
+                              "urn": 33,
+                              "grades": []
                             }
                           ]
                         }
-                      ]
-                    },
-                    {
-                      "urn": 202,
-                      "collection": "muslim",
-                      "bookNumber": "1",
-                      "chapterId": "2",
-                      "hadithNumber": "1",
-                      "name": "Sahih Muslim",
-                      "hadith": [
-                        {
-                          "lang": "en",
-                          "chapterNumber": "2",
-                          "chapterTitle": "Faith",
-                          "body": "Narrated Abu Huraira:...",
-                          "urn": 33,
-                          "grades": []
-                        }
-                      ]
+                      ],
+                      "page": 1,
+                      "limit": 4,
+                      "has_more": true,
+                      "language": "en",
+                      "direction": "ltr"
                     }
-                  ],
-                  "page": 1,
-                  "limit": 4,
-                  "has_more": true,
-                  "language": "en",
-                  "direction": "ltr"
+                  },
+                  "hadiths_found": {
+                    "summary": "Hadith references expanded into hadith text",
+                    "value": {
+                      "hadiths": [
+                        {
+                          "urn": 201,
+                          "collection": "bukhari",
+                          "bookNumber": "1",
+                          "chapterId": "1",
+                          "hadithNumber": "1",
+                          "name": "Sahih al-Bukhari",
+                          "hadith": [
+                            {
+                              "lang": "en",
+                              "chapterNumber": "1",
+                              "chapterTitle": "Revelation",
+                              "body": "Narrated Umar bin Al-Khattab:...",
+                              "urn": 31,
+                              "grades": [
+                                {
+                                  "graded_by": "Ahmad Muhammad Shakir",
+                                  "grade": "Sahih"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "urn": 202,
+                          "collection": "muslim",
+                          "bookNumber": "1",
+                          "chapterId": "2",
+                          "hadithNumber": "1",
+                          "name": "Sahih Muslim",
+                          "hadith": [
+                            {
+                              "lang": "en",
+                              "chapterNumber": "2",
+                              "chapterTitle": "Faith",
+                              "body": "Narrated Abu Huraira:...",
+                              "urn": 33,
+                              "grades": []
+                            }
+                          ]
+                        }
+                      ],
+                      "page": 1,
+                      "limit": 4,
+                      "has_more": true,
+                      "language": "en",
+                      "direction": "ltr"
+                    }
+                  },
+                  "no_hadiths": {
+                    "summary": "No hadiths for the selected ayah",
+                    "value": {
+                      "hadiths": [],
+                      "page": 1,
+                      "limit": 4,
+                      "has_more": false,
+                      "language": "en",
+                      "direction": "ltr"
+                    }
+                  }
                 }
               }
             }
@@ -1171,15 +1523,20 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 400,
-                  "error": {
-                    "code": "INVALID_PARAMETER",
-                    "message": "Invalid ayah_key format. Expected format: chapter:verse (e.g., 12:12)",
-                    "details": {
-                      "parameter": "ayah_key",
-                      "provided": "12-12",
-                      "expected": "12:12"
+                "examples": {
+                  "invalid_request": {
+                    "summary": "Invalid request",
+                    "value": {
+                      "status": 400,
+                      "error": {
+                        "code": "INVALID_PARAMETER",
+                        "message": "Invalid ayah_key format. Expected format: chapter:verse (e.g., 12:12)",
+                        "details": {
+                          "parameter": "ayah_key",
+                          "provided": "12-12",
+                          "expected": "12:12"
+                        }
+                      }
                     }
                   }
                 }
@@ -1199,12 +1556,17 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 404,
-                  "error": {
-                    "code": "NOT_FOUND",
-                    "message": "Verse 999:999 not found",
-                    "details": {}
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "status": 404,
+                      "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Verse 999:999 not found",
+                        "details": {}
+                      }
+                    }
                   }
                 }
               }
@@ -1220,12 +1582,17 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 500,
-                  "error": {
-                    "code": "CONFIGURATION_ERROR",
-                    "message": "SUNNAH_API_KEY is required",
-                    "details": {}
+                "examples": {
+                  "internal_server_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "status": 500,
+                      "error": {
+                        "code": "CONFIGURATION_ERROR",
+                        "message": "SUNNAH_API_KEY is required",
+                        "details": {}
+                      }
+                    }
                   }
                 }
               }
@@ -1238,13 +1605,18 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 502,
-                  "error": {
-                    "code": "UPSTREAM_ERROR",
-                    "message": "Too Many Requests.",
-                    "details": {
-                      "status": 429
+                "examples": {
+                  "bad_gateway": {
+                    "summary": "Bad gateway",
+                    "value": {
+                      "status": 502,
+                      "error": {
+                        "code": "UPSTREAM_ERROR",
+                        "message": "Too Many Requests.",
+                        "details": {
+                          "status": 429
+                        }
+                      }
                     }
                   }
                 }
@@ -1307,9 +1679,28 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-count-within-range-response"
                 },
-                "example": {
-                  "12:12": 2,
-                  "12:13": 2
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "12:12": 2,
+                      "12:13": 2
+                    }
+                  },
+                  "range_with_counts": {
+                    "summary": "Hadith counts by ayah key",
+                    "value": {
+                      "12:12": 2,
+                      "12:13": 2
+                    }
+                  },
+                  "range_with_no_matches": {
+                    "summary": "Verse range with no hadith references",
+                    "value": {
+                      "1:1": 0,
+                      "1:2": 0
+                    }
+                  }
                 }
               }
             }
@@ -1321,16 +1712,21 @@
                 "schema": {
                   "$ref": "#/components/schemas/hadith-error-response"
                 },
-                "example": {
-                  "status": 400,
-                  "error": {
-                    "code": "INVALID_PARAMETER",
-                    "message": "Missing required parameters: from and to",
-                    "details": {
-                      "required": [
-                        "from",
-                        "to"
-                      ]
+                "examples": {
+                  "invalid_request": {
+                    "summary": "Invalid request",
+                    "value": {
+                      "status": 400,
+                      "error": {
+                        "code": "INVALID_PARAMETER",
+                        "message": "Missing required parameters: from and to",
+                        "details": {
+                          "required": [
+                            "from",
+                            "to"
+                          ]
+                        }
+                      }
                     }
                   }
                 }
@@ -1423,19 +1819,51 @@
                     }
                   }
                 },
-                "example": {
-                  "pages": [
-                    {
-                      "id": 1,
-                      "page_number": 507,
-                      "verse_mapping": {
-                        "47:1": "47:3"
-                      },
-                      "first_verse_id": 4787,
-                      "last_verse_id": 4789,
-                      "verses_count": 3
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "pages": [
+                        {
+                          "id": 1,
+                          "page_number": 507,
+                          "verse_mapping": {
+                            "47:1": "47:3"
+                          },
+                          "first_verse_id": 4787,
+                          "last_verse_id": 4789,
+                          "verses_count": 3
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "first_mushaf_pages": {
+                    "summary": "First pages in the default mushaf",
+                    "value": {
+                      "pages": [
+                        {
+                          "id": 1,
+                          "page_number": 1,
+                          "verse_mapping": {
+                            "1": "1-7"
+                          },
+                          "first_verse_id": 1,
+                          "last_verse_id": 7,
+                          "verses_count": 7
+                        },
+                        {
+                          "id": 2,
+                          "page_number": 2,
+                          "verse_mapping": {
+                            "2": "1-5"
+                          },
+                          "first_verse_id": 8,
+                          "last_verse_id": 12,
+                          "verses_count": 5
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1617,24 +2045,71 @@
                     }
                   }
                 },
-                "example": {
-                  "total_page": 2,
-                  "lookup_range": {
-                    "from": "47:1",
-                    "to": "47:5"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "total_page": 2,
+                      "lookup_range": {
+                        "from": "47:1",
+                        "to": "47:5"
+                      },
+                      "pages": {
+                        "507": {
+                          "first_verse_key": "47:1",
+                          "last_verse_key": "47:3",
+                          "from": "47:1",
+                          "to": "47:3"
+                        },
+                        "508": {
+                          "first_verse_key": "47:4",
+                          "last_verse_key": "47:5",
+                          "from": "47:4",
+                          "to": "47:5"
+                        }
+                      }
+                    }
                   },
-                  "pages": {
-                    "507": {
-                      "first_verse_key": "47:1",
-                      "last_verse_key": "47:3",
-                      "from": "47:1",
-                      "to": "47:3"
-                    },
-                    "508": {
-                      "first_verse_key": "47:4",
-                      "last_verse_key": "47:5",
-                      "from": "47:4",
-                      "to": "47:5"
+                  "ayah_range_spans_pages": {
+                    "summary": "Ayah range split across multiple pages",
+                    "value": {
+                      "total_page": 2,
+                      "lookup_range": {
+                        "from": "47:1",
+                        "to": "47:5"
+                      },
+                      "pages": {
+                        "507": {
+                          "first_verse_key": "47:1",
+                          "last_verse_key": "47:3",
+                          "from": "47:1",
+                          "to": "47:3"
+                        },
+                        "508": {
+                          "first_verse_key": "47:4",
+                          "last_verse_key": "47:5",
+                          "from": "47:4",
+                          "to": "47:5"
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_lookup": {
+                    "summary": "Single ayah page lookup",
+                    "value": {
+                      "total_page": 1,
+                      "lookup_range": {
+                        "from": "2:255",
+                        "to": "2:255"
+                      },
+                      "pages": {
+                        "42": {
+                          "first_verse_key": "2:253",
+                          "last_verse_key": "2:256",
+                          "from": "2:255",
+                          "to": "2:255"
+                        }
+                      }
                     }
                   }
                 }
@@ -1760,16 +2235,21 @@
                     }
                   }
                 },
-                "example": {
-                  "page": {
-                    "id": 1,
-                    "page_number": 507,
-                    "verse_mapping": {
-                      "47:1": "47:3"
-                    },
-                    "first_verse_id": 4787,
-                    "last_verse_id": 4789,
-                    "verses_count": 3
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "page": {
+                        "id": 1,
+                        "page_number": 507,
+                        "verse_mapping": {
+                          "47:1": "47:3"
+                        },
+                        "first_verse_id": 4787,
+                        "last_verse_id": 4789,
+                        "verses_count": 3
+                      }
+                    }
                   }
                 }
               }
@@ -1963,59 +2443,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -2251,59 +2826,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -2531,59 +3201,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -2812,59 +3577,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -3073,59 +3933,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -3354,61 +4309,156 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 1,
-                      "manzil_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -3617,495 +4667,590 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 8,
-                      "verse_number": 1,
-                      "verse_key": "2:1",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "الٓمّٓۚ‏",
-                      "page_number": 2,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002001.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            30,
-                            7080
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "id": 9,
-                      "verse_number": 2,
-                      "verse_key": "2:2",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "ذٰلِكَ الۡڪِتٰبُ لَا رَيۡبَۛۚۖ فِيۡهِۛۚ هُدًى لِّلۡمُتَّقِيۡنَۙ‏",
-                      "page_number": 2,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002002.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            150,
-                            860
-                          ],
-                          [
-                            1,
-                            2,
-                            870,
-                            1820
-                          ],
-                          [
-                            2,
-                            3,
-                            1830,
-                            2130
-                          ],
-                          [
-                            3,
-                            4,
-                            2140,
-                            2680
-                          ],
-                          [
-                            4,
-                            5,
-                            2690,
-                            4980
-                          ],
-                          [
-                            5,
-                            6,
-                            4990,
-                            5180
-                          ],
-                          [
-                            6,
-                            7,
-                            5190,
-                            8610
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "id": 10,
-                      "verse_number": 3,
-                      "verse_key": "2:3",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "الَّذِيۡنَ يُؤۡمِنُوۡنَ بِالۡغَيۡبِ وَ يُقِيۡمُوۡنَ الصَّلٰوةَ وَمِمَّا رَزَقۡنٰهُمۡ يُن۫فِقُوۡنَۙ‏",
-                      "page_number": 2,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002003.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            30,
-                            1010
-                          ],
-                          [
-                            1,
-                            2,
-                            1020,
-                            2120
-                          ],
-                          [
-                            2,
-                            3,
-                            2130,
-                            3070
-                          ],
-                          [
-                            3,
-                            4,
-                            3080,
-                            4200
-                          ],
-                          [
-                            4,
-                            5,
-                            4210,
-                            5130
-                          ],
-                          [
-                            5,
-                            6,
-                            5140,
-                            6570
-                          ],
-                          [
-                            6,
-                            7,
-                            6580,
-                            7930
-                          ],
-                          [
-                            7,
-                            8,
-                            7940,
-                            11060
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "id": 11,
-                      "verse_number": 4,
-                      "verse_key": "2:4",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "وَالَّذِيۡنَ يُؤۡمِنُوۡنَ بِمَۤا اُنۡزِلَ اِلَيۡكَ وَمَاۤ اُنۡزِلَ مِنۡ قَبۡلِكَۚ وَبِالۡاٰخِرَةِ هُمۡ يُوۡقِنُوۡنَؕ‏",
-                      "page_number": 2,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002004.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            50,
-                            1120
-                          ],
-                          [
-                            1,
-                            2,
-                            1130,
-                            2190
-                          ],
-                          [
-                            2,
-                            3,
-                            2200,
-                            3920
-                          ],
-                          [
-                            3,
-                            4,
-                            3930,
-                            5250
-                          ],
-                          [
-                            4,
-                            5,
-                            5260,
-                            5960
-                          ],
-                          [
-                            5,
-                            6,
-                            5970,
-                            6180
-                          ],
-                          [
-                            6,
-                            7,
-                            6190,
-                            9020
-                          ],
-                          [
-                            7,
-                            8,
-                            9030,
-                            9830
-                          ],
-                          [
-                            8,
-                            9,
-                            9840,
-                            10640
-                          ],
-                          [
-                            9,
-                            10,
-                            10650,
-                            12110
-                          ],
-                          [
-                            10,
-                            11,
-                            12120,
-                            12460
-                          ],
-                          [
-                            11,
-                            12,
-                            12470,
-                            15480
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "id": 12,
-                      "verse_number": 5,
-                      "verse_key": "2:5",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "اُولٰٓٮِٕكَ عَلٰى هُدًى مِّنۡ رَّبِّهِمۡ​ وَاُولٰٓٮِٕكَ هُمُ الۡمُفۡلِحُوۡنَ‏ ﻿﻿",
-                      "page_number": 2,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002005.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            70,
-                            2490
-                          ],
-                          [
-                            1,
-                            2,
-                            2500,
-                            3030
-                          ],
-                          [
-                            2,
-                            3,
-                            3040,
-                            3480
-                          ],
-                          [
-                            3,
-                            4,
-                            3490,
-                            4240
-                          ],
-                          [
-                            4,
-                            5,
-                            4250,
-                            5490
-                          ],
-                          [
-                            5,
-                            6,
-                            5500,
-                            7970
-                          ],
-                          [
-                            6,
-                            7,
-                            7980,
-                            8380
-                          ],
-                          [
-                            7,
-                            8,
-                            8390,
-                            10970
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "id": 13,
-                      "verse_number": 6,
-                      "verse_key": "2:6",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "اِنَّ الَّذِيۡنَ كَفَرُوۡا سَوَآءٌ عَلَيۡهِمۡ ءَاَنۡذَرۡتَهُمۡ اَمۡ لَمۡ تُنۡذِرۡهُمۡ لَا يُؤۡمِنُوۡنَ‏",
-                      "page_number": 3,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002006.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            30,
-                            1260
-                          ],
-                          [
-                            1,
-                            2,
-                            1270,
-                            2150
-                          ],
-                          [
-                            2,
-                            3,
-                            2160,
-                            2880
-                          ],
-                          [
-                            3,
-                            4,
-                            2890,
-                            4950
-                          ],
-                          [
-                            4,
-                            5,
-                            4960,
-                            5880
-                          ],
-                          [
-                            5,
-                            6,
-                            5890,
-                            7780
-                          ],
-                          [
-                            6,
-                            7,
-                            7790,
-                            8090
-                          ],
-                          [
-                            7,
-                            8,
-                            8100,
-                            8430
-                          ],
-                          [
-                            8,
-                            9,
-                            8440,
-                            10080
-                          ],
-                          [
-                            9,
-                            10,
-                            10090,
-                            10430
-                          ],
-                          [
-                            10,
-                            11,
-                            10440,
-                            12340
-                          ]
-                        ]
-                      }
-                    },
-                    {
-                      "id": 14,
-                      "verse_number": 7,
-                      "verse_key": "2:7",
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "ruku_number": 2,
-                      "manzil_number": 1,
-                      "sajdah_number": null,
-                      "text_indopak": "خَتَمَ اللّٰهُ عَلَىٰ قُلُوۡبِهِمۡ وَعَلٰى سَمۡعِهِمۡ​ؕ وَعَلٰىٓ اَبۡصَارِهِمۡ غِشَاوَةٌ  وَّلَهُمۡ عَذَابٌ عَظِيۡمٌ‏",
-                      "page_number": 3,
-                      "juz_number": 1,
-                      "audio": {
-                        "url": "Alafasy/mp3/002007.mp3",
-                        "segments": [
-                          [
-                            0,
-                            1,
-                            140,
-                            660
-                          ],
-                          [
-                            1,
-                            2,
-                            670,
-                            1390
-                          ],
-                          [
-                            2,
-                            3,
-                            1400,
-                            1950
-                          ],
-                          [
-                            3,
-                            4,
-                            1960,
-                            3140
-                          ],
-                          [
-                            4,
-                            5,
-                            3150,
-                            3820
-                          ],
-                          [
-                            5,
-                            6,
-                            3830,
-                            5210
-                          ],
-                          [
-                            6,
-                            7,
-                            5220,
-                            6900
-                          ],
-                          [
-                            7,
-                            8,
-                            6910,
-                            8250
-                          ],
-                          [
-                            8,
-                            9,
-                            8260,
-                            9580
-                          ],
-                          [
-                            9,
-                            10,
-                            9590,
-                            10260
-                          ],
-                          [
-                            10,
-                            11,
-                            10270,
-                            11230
-                          ],
-                          [
-                            11,
-                            12,
-                            11240,
-                            12940
-                          ]
-                        ]
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 8,
+                          "verse_number": 1,
+                          "verse_key": "2:1",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "الٓمّٓۚ‏",
+                          "page_number": 2,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002001.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                30,
+                                7080
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "id": 9,
+                          "verse_number": 2,
+                          "verse_key": "2:2",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "ذٰلِكَ الۡڪِتٰبُ لَا رَيۡبَۛۚۖ فِيۡهِۛۚ هُدًى لِّلۡمُتَّقِيۡنَۙ‏",
+                          "page_number": 2,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002002.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                150,
+                                860
+                              ],
+                              [
+                                1,
+                                2,
+                                870,
+                                1820
+                              ],
+                              [
+                                2,
+                                3,
+                                1830,
+                                2130
+                              ],
+                              [
+                                3,
+                                4,
+                                2140,
+                                2680
+                              ],
+                              [
+                                4,
+                                5,
+                                2690,
+                                4980
+                              ],
+                              [
+                                5,
+                                6,
+                                4990,
+                                5180
+                              ],
+                              [
+                                6,
+                                7,
+                                5190,
+                                8610
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "id": 10,
+                          "verse_number": 3,
+                          "verse_key": "2:3",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "الَّذِيۡنَ يُؤۡمِنُوۡنَ بِالۡغَيۡبِ وَ يُقِيۡمُوۡنَ الصَّلٰوةَ وَمِمَّا رَزَقۡنٰهُمۡ يُن۫فِقُوۡنَۙ‏",
+                          "page_number": 2,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002003.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                30,
+                                1010
+                              ],
+                              [
+                                1,
+                                2,
+                                1020,
+                                2120
+                              ],
+                              [
+                                2,
+                                3,
+                                2130,
+                                3070
+                              ],
+                              [
+                                3,
+                                4,
+                                3080,
+                                4200
+                              ],
+                              [
+                                4,
+                                5,
+                                4210,
+                                5130
+                              ],
+                              [
+                                5,
+                                6,
+                                5140,
+                                6570
+                              ],
+                              [
+                                6,
+                                7,
+                                6580,
+                                7930
+                              ],
+                              [
+                                7,
+                                8,
+                                7940,
+                                11060
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "id": 11,
+                          "verse_number": 4,
+                          "verse_key": "2:4",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "وَالَّذِيۡنَ يُؤۡمِنُوۡنَ بِمَۤا اُنۡزِلَ اِلَيۡكَ وَمَاۤ اُنۡزِلَ مِنۡ قَبۡلِكَۚ وَبِالۡاٰخِرَةِ هُمۡ يُوۡقِنُوۡنَؕ‏",
+                          "page_number": 2,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002004.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                50,
+                                1120
+                              ],
+                              [
+                                1,
+                                2,
+                                1130,
+                                2190
+                              ],
+                              [
+                                2,
+                                3,
+                                2200,
+                                3920
+                              ],
+                              [
+                                3,
+                                4,
+                                3930,
+                                5250
+                              ],
+                              [
+                                4,
+                                5,
+                                5260,
+                                5960
+                              ],
+                              [
+                                5,
+                                6,
+                                5970,
+                                6180
+                              ],
+                              [
+                                6,
+                                7,
+                                6190,
+                                9020
+                              ],
+                              [
+                                7,
+                                8,
+                                9030,
+                                9830
+                              ],
+                              [
+                                8,
+                                9,
+                                9840,
+                                10640
+                              ],
+                              [
+                                9,
+                                10,
+                                10650,
+                                12110
+                              ],
+                              [
+                                10,
+                                11,
+                                12120,
+                                12460
+                              ],
+                              [
+                                11,
+                                12,
+                                12470,
+                                15480
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "id": 12,
+                          "verse_number": 5,
+                          "verse_key": "2:5",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "اُولٰٓٮِٕكَ عَلٰى هُدًى مِّنۡ رَّبِّهِمۡ​ وَاُولٰٓٮِٕكَ هُمُ الۡمُفۡلِحُوۡنَ‏ ﻿﻿",
+                          "page_number": 2,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002005.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                70,
+                                2490
+                              ],
+                              [
+                                1,
+                                2,
+                                2500,
+                                3030
+                              ],
+                              [
+                                2,
+                                3,
+                                3040,
+                                3480
+                              ],
+                              [
+                                3,
+                                4,
+                                3490,
+                                4240
+                              ],
+                              [
+                                4,
+                                5,
+                                4250,
+                                5490
+                              ],
+                              [
+                                5,
+                                6,
+                                5500,
+                                7970
+                              ],
+                              [
+                                6,
+                                7,
+                                7980,
+                                8380
+                              ],
+                              [
+                                7,
+                                8,
+                                8390,
+                                10970
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "id": 13,
+                          "verse_number": 6,
+                          "verse_key": "2:6",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "اِنَّ الَّذِيۡنَ كَفَرُوۡا سَوَآءٌ عَلَيۡهِمۡ ءَاَنۡذَرۡتَهُمۡ اَمۡ لَمۡ تُنۡذِرۡهُمۡ لَا يُؤۡمِنُوۡنَ‏",
+                          "page_number": 3,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002006.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                30,
+                                1260
+                              ],
+                              [
+                                1,
+                                2,
+                                1270,
+                                2150
+                              ],
+                              [
+                                2,
+                                3,
+                                2160,
+                                2880
+                              ],
+                              [
+                                3,
+                                4,
+                                2890,
+                                4950
+                              ],
+                              [
+                                4,
+                                5,
+                                4960,
+                                5880
+                              ],
+                              [
+                                5,
+                                6,
+                                5890,
+                                7780
+                              ],
+                              [
+                                6,
+                                7,
+                                7790,
+                                8090
+                              ],
+                              [
+                                7,
+                                8,
+                                8100,
+                                8430
+                              ],
+                              [
+                                8,
+                                9,
+                                8440,
+                                10080
+                              ],
+                              [
+                                9,
+                                10,
+                                10090,
+                                10430
+                              ],
+                              [
+                                10,
+                                11,
+                                10440,
+                                12340
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "id": 14,
+                          "verse_number": 7,
+                          "verse_key": "2:7",
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "ruku_number": 2,
+                          "manzil_number": 1,
+                          "sajdah_number": null,
+                          "text_indopak": "خَتَمَ اللّٰهُ عَلَىٰ قُلُوۡبِهِمۡ وَعَلٰى سَمۡعِهِمۡ​ؕ وَعَلٰىٓ اَبۡصَارِهِمۡ غِشَاوَةٌ  وَّلَهُمۡ عَذَابٌ عَظِيۡمٌ‏",
+                          "page_number": 3,
+                          "juz_number": 1,
+                          "audio": {
+                            "url": "Alafasy/mp3/002007.mp3",
+                            "segments": [
+                              [
+                                0,
+                                1,
+                                140,
+                                660
+                              ],
+                              [
+                                1,
+                                2,
+                                670,
+                                1390
+                              ],
+                              [
+                                2,
+                                3,
+                                1400,
+                                1950
+                              ],
+                              [
+                                3,
+                                4,
+                                1960,
+                                3140
+                              ],
+                              [
+                                4,
+                                5,
+                                3150,
+                                3820
+                              ],
+                              [
+                                5,
+                                6,
+                                3830,
+                                5210
+                              ],
+                              [
+                                6,
+                                7,
+                                5220,
+                                6900
+                              ],
+                              [
+                                7,
+                                8,
+                                6910,
+                                8250
+                              ],
+                              [
+                                8,
+                                9,
+                                8260,
+                                9580
+                              ],
+                              [
+                                9,
+                                10,
+                                9590,
+                                10260
+                              ],
+                              [
+                                10,
+                                11,
+                                10270,
+                                11230
+                              ],
+                              [
+                                11,
+                                12,
+                                11240,
+                                12940
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 7,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 7
                       }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 7,
-                    "current_page": 1,
-                    "next_page": null,
-                    "total_pages": 1,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -4341,59 +5486,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -4597,50 +5837,127 @@
                     }
                   }
                 },
-                "example": {
-                  "verse": {
-                    "id": 1,
-                    "verse_number": 1,
-                    "page_number": 1,
-                    "verse_key": "1:1",
-                    "juz_number": 1,
-                    "hizb_number": 1,
-                    "rub_el_hizb_number": 1,
-                    "sajdah_type": null,
-                    "sajdah_number": null,
-                    "words": [
-                      {
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verse": {
                         "id": 1,
-                        "position": 1,
-                        "audio_url": "wbw/001_001_001.mp3",
-                        "char_type_name": "word",
-                        "line_number": 2,
+                        "verse_number": 1,
                         "page_number": 1,
-                        "code_v1": "&#xfb51;",
-                        "translation": {
-                          "text": "In (the) name",
-                          "language_name": "english"
+                        "verse_key": "1:1",
+                        "juz_number": 1,
+                        "hizb_number": 1,
+                        "rub_el_hizb_number": 1,
+                        "sajdah_type": null,
+                        "sajdah_number": null,
+                        "words": [
+                          {
+                            "id": 1,
+                            "position": 1,
+                            "audio_url": "wbw/001_001_001.mp3",
+                            "char_type_name": "word",
+                            "line_number": 2,
+                            "page_number": 1,
+                            "code_v1": "&#xfb51;",
+                            "translation": {
+                              "text": "In (the) name",
+                              "language_name": "english"
+                            },
+                            "transliteration": {
+                              "text": "bis'mi",
+                              "language_name": "english"
+                            }
+                          }
+                        ],
+                        "translations": [
+                          {
+                            "resource_id": 131,
+                            "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                          }
+                        ],
+                        "tafsirs": [
+                          {
+                            "id": 82641,
+                            "language_name": "english",
+                            "name": "Tafsir Ibn Kathir",
+                            "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "compact_verse": {
+                    "summary": "Compact single verse response",
+                    "value": {
+                      "verse": {
+                        "id": 255,
+                        "chapter_id": 2,
+                        "verse_number": 255,
+                        "verse_key": "2:255",
+                        "verse_index": 262,
+                        "juz_number": 3,
+                        "hizb_number": 5,
+                        "rub_el_hizb_number": 19,
+                        "page_number": 42
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Single verse with words, translation, tafsir, and audio",
+                    "value": {
+                      "verse": {
+                        "id": 1,
+                        "chapter_id": 1,
+                        "verse_number": 1,
+                        "page_number": 1,
+                        "verse_key": "1:1",
+                        "juz_number": 1,
+                        "hizb_number": 1,
+                        "rub_el_hizb_number": 1,
+                        "sajdah_type": null,
+                        "sajdah_number": null,
+                        "audio": {
+                          "verse_key": "1:1",
+                          "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
                         },
-                        "transliteration": {
-                          "text": "bis'mi",
-                          "language_name": "english"
-                        }
+                        "words": [
+                          {
+                            "id": 1,
+                            "position": 1,
+                            "audio_url": "wbw/001_001_001.mp3",
+                            "char_type_name": "word",
+                            "line_number": 2,
+                            "page_number": 1,
+                            "code_v1": "&#xfb51;",
+                            "translation": {
+                              "text": "In (the) name",
+                              "language_name": "english"
+                            },
+                            "transliteration": {
+                              "text": "bis'mi",
+                              "language_name": "english"
+                            }
+                          }
+                        ],
+                        "translations": [
+                          {
+                            "resource_id": 131,
+                            "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                            "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                          }
+                        ],
+                        "tafsirs": [
+                          {
+                            "id": 82641,
+                            "resource_id": 169,
+                            "language_name": "english",
+                            "name": "Tafsir Ibn Kathir",
+                            "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                          }
+                        ]
                       }
-                    ],
-                    "translations": [
-                      {
-                        "resource_id": 131,
-                        "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                      }
-                    ],
-                    "tafsirs": [
-                      {
-                        "id": 82641,
-                        "language_name": "english",
-                        "name": "Tafsir Ibn Kathir",
-                        "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -4904,50 +6221,127 @@
                     }
                   }
                 },
-                "example": {
-                  "verse": {
-                    "id": 1,
-                    "verse_number": 1,
-                    "page_number": 1,
-                    "verse_key": "1:1",
-                    "juz_number": 1,
-                    "hizb_number": 1,
-                    "rub_el_hizb_number": 1,
-                    "sajdah_type": null,
-                    "sajdah_number": null,
-                    "words": [
-                      {
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verse": {
                         "id": 1,
-                        "position": 1,
-                        "audio_url": "wbw/001_001_001.mp3",
-                        "char_type_name": "word",
-                        "line_number": 2,
+                        "verse_number": 1,
                         "page_number": 1,
-                        "code_v1": "&#xfb51;",
-                        "translation": {
-                          "text": "In (the) name",
-                          "language_name": "english"
+                        "verse_key": "1:1",
+                        "juz_number": 1,
+                        "hizb_number": 1,
+                        "rub_el_hizb_number": 1,
+                        "sajdah_type": null,
+                        "sajdah_number": null,
+                        "words": [
+                          {
+                            "id": 1,
+                            "position": 1,
+                            "audio_url": "wbw/001_001_001.mp3",
+                            "char_type_name": "word",
+                            "line_number": 2,
+                            "page_number": 1,
+                            "code_v1": "&#xfb51;",
+                            "translation": {
+                              "text": "In (the) name",
+                              "language_name": "english"
+                            },
+                            "transliteration": {
+                              "text": "bis'mi",
+                              "language_name": "english"
+                            }
+                          }
+                        ],
+                        "translations": [
+                          {
+                            "resource_id": 131,
+                            "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                          }
+                        ],
+                        "tafsirs": [
+                          {
+                            "id": 82641,
+                            "language_name": "english",
+                            "name": "Tafsir Ibn Kathir",
+                            "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "compact_verse": {
+                    "summary": "Compact single verse response",
+                    "value": {
+                      "verse": {
+                        "id": 255,
+                        "chapter_id": 2,
+                        "verse_number": 255,
+                        "verse_key": "2:255",
+                        "verse_index": 262,
+                        "juz_number": 3,
+                        "hizb_number": 5,
+                        "rub_el_hizb_number": 19,
+                        "page_number": 42
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Single verse with words, translation, tafsir, and audio",
+                    "value": {
+                      "verse": {
+                        "id": 1,
+                        "chapter_id": 1,
+                        "verse_number": 1,
+                        "page_number": 1,
+                        "verse_key": "1:1",
+                        "juz_number": 1,
+                        "hizb_number": 1,
+                        "rub_el_hizb_number": 1,
+                        "sajdah_type": null,
+                        "sajdah_number": null,
+                        "audio": {
+                          "verse_key": "1:1",
+                          "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
                         },
-                        "transliteration": {
-                          "text": "bis'mi",
-                          "language_name": "english"
-                        }
+                        "words": [
+                          {
+                            "id": 1,
+                            "position": 1,
+                            "audio_url": "wbw/001_001_001.mp3",
+                            "char_type_name": "word",
+                            "line_number": 2,
+                            "page_number": 1,
+                            "code_v1": "&#xfb51;",
+                            "translation": {
+                              "text": "In (the) name",
+                              "language_name": "english"
+                            },
+                            "transliteration": {
+                              "text": "bis'mi",
+                              "language_name": "english"
+                            }
+                          }
+                        ],
+                        "translations": [
+                          {
+                            "resource_id": 131,
+                            "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                            "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                          }
+                        ],
+                        "tafsirs": [
+                          {
+                            "id": 82641,
+                            "resource_id": 169,
+                            "language_name": "english",
+                            "name": "Tafsir Ibn Kathir",
+                            "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                          }
+                        ]
                       }
-                    ],
-                    "translations": [
-                      {
-                        "resource_id": 131,
-                        "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                      }
-                    ],
-                    "tafsirs": [
-                      {
-                        "id": 82641,
-                        "language_name": "english",
-                        "name": "Tafsir Ibn Kathir",
-                        "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -5075,20 +6469,25 @@
                     }
                   }
                 },
-                "example": {
-                  "juzs": [
-                    {
-                      "id": 1,
-                      "juz_number": 1,
-                      "verse_mapping": {
-                        "1": "1-7",
-                        "2": "1-141"
-                      },
-                      "first_verse_id": 1,
-                      "last_verse_id": 148,
-                      "verses_count": 148
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "juzs": [
+                        {
+                          "id": 1,
+                          "juz_number": 1,
+                          "verse_mapping": {
+                            "1": "1-7",
+                            "2": "1-141"
+                          },
+                          "first_verse_id": 1,
+                          "last_verse_id": 148,
+                          "verses_count": 148
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -5322,17 +6721,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -5535,17 +6973,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_indopak": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_indopak": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_indopak": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_indopak": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -5748,17 +7225,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_indopak_nastaleeq": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_indopak_nastaleeq": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_indopak_nastaleeq": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_indopak_nastaleeq": "بِسۡمِ اللهِ الرَّحۡمٰنِ الرَّحِيۡمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -5961,17 +7477,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_uthmani_tajweed": "بِسْمِ <tajweed class=ham_wasl>ٱ</tajweed>للَّهِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّحْمَ<tajweed class=madda_normal>ـٰ</tajweed>نِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّح<tajweed class=madda_permissible>ِي</tajweed>مِ <span class=end>١</span>"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani_tajweed": "بِسْمِ <tajweed class=ham_wasl>ٱ</tajweed>للَّهِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّحْمَ<tajweed class=madda_normal>ـٰ</tajweed>نِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّح<tajweed class=madda_permissible>ِي</tajweed>مِ <span class=end>١</span>"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani_tajweed": "بِسْمِ <tajweed class=ham_wasl>ٱ</tajweed>للَّهِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّحْمَ<tajweed class=madda_normal>ـٰ</tajweed>نِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّح<tajweed class=madda_permissible>ِي</tajweed>مِ <span class=end>١</span>"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani_tajweed": "بِسْمِ <tajweed class=ham_wasl>ٱ</tajweed>للَّهِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّحْمَ<tajweed class=madda_normal>ـٰ</tajweed>نِ <tajweed class=ham_wasl>ٱ</tajweed><tajweed class=laam_shamsiyah>ل</tajweed>رَّح<tajweed class=madda_permissible>ِي</tajweed>مِ <span class=end>١</span>"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -6174,17 +7729,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani": "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -6387,17 +7981,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_uthmani_simple": "بسم الله الرحمن الرحيم"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani_simple": "بسم الله الرحمن الرحيم"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani_simple": "بسم الله الرحمن الرحيم"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_uthmani_simple": "بسم الله الرحمن الرحيم"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -6600,17 +8233,56 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "text_imlaei": "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_imlaei": "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter": {
+                    "summary": "Text for a chapter filter",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_imlaei": "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "single_ayah_filter": {
+                    "summary": "Text for one ayah",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "text_imlaei": "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ"
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "verse_key": "1:1"
+                        }
+                      }
                     }
                   }
                 }
@@ -6740,18 +8412,48 @@
                     }
                   }
                 },
-                "example": {
-                  "recitations": [
-                    {
-                      "id": 1,
-                      "reciter_name": "AbdulBaset AbdulSamad",
-                      "style": "Mujawwad",
-                      "translated_name": {
-                        "name": "AbdulBaset AbdulSamad",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "recitations": [
+                        {
+                          "id": 1,
+                          "reciter_name": "AbdulBaset AbdulSamad",
+                          "style": "Mujawwad",
+                          "translated_name": {
+                            "name": "AbdulBaset AbdulSamad",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "murattal_and_mujawwad_reciters": {
+                    "summary": "Recitation resources with different styles",
+                    "value": {
+                      "recitations": [
+                        {
+                          "id": 1,
+                          "reciter_name": "AbdulBaset AbdulSamad",
+                          "style": "Mujawwad",
+                          "translated_name": {
+                            "name": "AbdulBaset AbdulSamad",
+                            "language_name": "english"
+                          }
+                        },
+                        {
+                          "id": 7,
+                          "reciter_name": "Mishari Rashid al-Afasy",
+                          "style": "Murattal",
+                          "translated_name": {
+                            "name": "Mishari Rashid al-Afasy",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -6973,40 +8675,67 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "Alafasy/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "Alafasy/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "Alafasy/mp3/001003.mp3"
-                    },
-                    {
-                      "verse_key": "1:4",
-                      "url": "Alafasy/mp3/001004.mp3"
-                    },
-                    {
-                      "verse_key": "1:5",
-                      "url": "Alafasy/mp3/001005.mp3"
-                    },
-                    {
-                      "verse_key": "1:6",
-                      "url": "Alafasy/mp3/001006.mp3"
-                    },
-                    {
-                      "verse_key": "1:7",
-                      "url": "Alafasy/mp3/001007.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "Alafasy/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "Alafasy/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "Alafasy/mp3/001003.mp3"
+                        },
+                        {
+                          "verse_key": "1:4",
+                          "url": "Alafasy/mp3/001004.mp3"
+                        },
+                        {
+                          "verse_key": "1:5",
+                          "url": "Alafasy/mp3/001005.mp3"
+                        },
+                        {
+                          "verse_key": "1:6",
+                          "url": "Alafasy/mp3/001006.mp3"
+                        },
+                        {
+                          "verse_key": "1:7",
+                          "url": "Alafasy/mp3/001007.mp3"
+                        }
+                      ],
+                      "meta": {
+                        "reciter_name": "Mishari Rashid al-`Afasy",
+                        "recitation_style": null
+                      }
                     }
-                  ],
-                  "meta": {
-                    "reciter_name": "Mishari Rashid al-`Afasy",
-                    "recitation_style": null
+                  },
+                  "chapter_audio_files": {
+                    "summary": "Ayah-by-ayah audio files for a chapter",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "Alafasy/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "Alafasy/mp3/001002.mp3"
+                        }
+                      ],
+                      "meta": {
+                        "reciter_name": "Mishari Rashid al-Afasy",
+                        "recitation_style": null,
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -7235,35 +8964,108 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "resource_id": 131,
-                      "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
-                      "id": 903958,
-                      "text": "In the Name of Allah - the Most Compassionate, Most Merciful.",
-                      "verse_id": 1,
-                      "language_id": 38,
-                      "language_name": "english",
-                      "verse_key": "1:1",
-                      "chapter_id": 1,
-                      "verse_number": 1,
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "page_number": 1,
-                      "ruku_number": 1,
-                      "manzil_number": 1,
-                      "foot_notes": {
-                        "1": "Some editions note variant readings here."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah - the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions note variant readings here."
+                          }
+                        }
+                      ],
+                      "meta": {
+                        "translation_name": "Dr. Mustafa Khattab, the Clear Quran",
+                        "author_name": "Dr. Mustafa Khattab",
+                        "filters": {
+                          "chapter_number": 1
+                        }
                       }
                     }
-                  ],
-                  "meta": {
-                    "translation_name": "Dr. Mustafa Khattab, the Clear Quran",
-                    "author_name": "Dr. Mustafa Khattab",
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "chapter_filter_with_footnotes": {
+                    "summary": "Translation chapter filter with footnotes",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "meta": {
+                        "translation_name": "Dr. Mustafa Khattab, the Clear Quran",
+                        "author_name": "Dr. Mustafa Khattab",
+                        "filters": {
+                          "chapter_number": 1,
+                          "foot_notes": true
+                        }
+                      }
+                    }
+                  },
+                  "verse_key_without_footnotes": {
+                    "summary": "Single ayah translation without footnotes",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 904212,
+                          "text": "Allah! There is no god except Him, the Ever-Living, All-Sustaining.",
+                          "verse_id": 255,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "2:255",
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42,
+                          "ruku_number": 35,
+                          "manzil_number": 1
+                        }
+                      ],
+                      "meta": {
+                        "translation_name": "Dr. Mustafa Khattab, the Clear Quran",
+                        "author_name": "Dr. Mustafa Khattab",
+                        "filters": {
+                          "verse_key": "2:255"
+                        }
+                      }
                     }
                   }
                 }
@@ -7393,25 +9195,30 @@
                     }
                   }
                 },
-                "example": {
-                  "reciters": [
-                    {
-                      "id": 3,
-                      "name": "Abu Bakr al-Shatri",
-                      "style": {
-                        "name": "Murattal",
-                        "language_name": "english"
-                      },
-                      "qirat": {
-                        "name": "Hafs",
-                        "language_name": "english"
-                      },
-                      "translated_name": {
-                        "name": "Abu Bakr al-Shatri",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "reciters": [
+                        {
+                          "id": 3,
+                          "name": "Abu Bakr al-Shatri",
+                          "style": {
+                            "name": "Murattal",
+                            "language_name": "english"
+                          },
+                          "qirat": {
+                            "name": "Hafs",
+                            "language_name": "english"
+                          },
+                          "translated_name": {
+                            "name": "Abu Bakr al-Shatri",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -7633,16 +9440,87 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "resource_id": 169,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2><p>This Surah is called</p><p>-        Al-Fatihah, that is, the Opener of the Book, the Surah with which prayers are begun."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "resource_id": 169,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2><p>This Surah is called</p><p>-        Al-Fatihah, that is, the Opener of the Book, the Surah with which prayers are begun."
+                        }
+                      ],
+                      "meta": {
+                        "tafsir_name": "Tafsir Ibn Kathir",
+                        "author_name": "Hafiz Ibn Kathir"
+                      }
                     }
-                  ],
-                  "meta": {
-                    "tafsir_name": "Tafsir Ibn Kathir",
-                    "author_name": "Hafiz Ibn Kathir"
+                  },
+                  "chapter_filter": {
+                    "summary": "Tafsir records for a chapter",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "meta": {
+                        "tafsir_name": "Tafsir Ibn Kathir",
+                        "author_name": "Hafiz Ibn Kathir",
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
+                    }
+                  },
+                  "verse_key_filter": {
+                    "summary": "Tafsir record for one ayah",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 255,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "2:255",
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "meta": {
+                        "tafsir_name": "Tafsir Ibn Kathir",
+                        "author_name": "Hafiz Ibn Kathir",
+                        "filters": {
+                          "verse_key": "2:255"
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -7844,17 +9722,40 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "v1_page": 1
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "v1_page": 1
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "qcf_v1_font_page": {
+                    "summary": "QCF v1 glyphs for a font page",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "code_v1": "&#xfb51;",
+                          "v1_page": 1
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
                   }
                 }
@@ -8057,17 +9958,40 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_key": "1:1",
-                      "v2_page": 1
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "v2_page": 1
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
-                  ],
-                  "meta": {
-                    "filters": {
-                      "chapter_number": 1
+                  },
+                  "qcf_v2_font_page": {
+                    "summary": "QCF v2 glyphs for a font page",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "verse_key": "1:1",
+                          "code_v2": "&#xE001;",
+                          "v2_page": 1
+                        }
+                      ],
+                      "meta": {
+                        "filters": {
+                          "chapter_number": 1
+                        }
+                      }
                     }
                   }
                 }
@@ -8449,27 +10373,32 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 2,
+                        "total_records": 20
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 2,
-                    "total_records": 20
                   }
                 }
               }
@@ -8640,27 +10569,32 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -8831,27 +10765,32 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -9022,27 +10961,32 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -9212,27 +11156,32 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -9368,10 +11317,15 @@
                     }
                   }
                 },
-                "example": {
-                  "info": {
-                    "id": 1,
-                    "info": null
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "info": {
+                        "id": 1,
+                        "info": null
+                      }
+                    }
                   }
                 }
               }
@@ -9506,10 +11460,15 @@
                     }
                   }
                 },
-                "example": {
-                  "info": {
-                    "id": 1,
-                    "info": null
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "info": {
+                        "id": 1,
+                        "info": null
+                      }
+                    }
                   }
                 }
               }
@@ -9634,20 +11593,61 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 131,
-                      "name": "Dr. Mustafa Khattab, the Clear Quran",
-                      "author_name": "Dr. Mustafa Khattab",
-                      "slug": "clearquran-with-tafsir",
-                      "language_name": "english",
-                      "translated_name": {
-                        "name": "Dr. Mustafa Khattab",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 131,
+                          "name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "author_name": "Dr. Mustafa Khattab",
+                          "slug": "clearquran-with-tafsir",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Dr. Mustafa Khattab",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "english_translation_resources": {
+                    "summary": "English translation resources",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 131,
+                          "name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "author_name": "Dr. Mustafa Khattab",
+                          "slug": "clearquran-with-tafsir",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Dr. Mustafa Khattab",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "urdu_translation_resources": {
+                    "summary": "Non-English translation resources",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 97,
+                          "name": "Taqi Usmani",
+                          "author_name": "Mufti Taqi Usmani",
+                          "slug": "taqi-usmani",
+                          "language_name": "urdu",
+                          "translated_name": {
+                            "name": "Taqi Usmani",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -9772,20 +11772,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 169,
-                      "name": "Tafsir Ibn Kathir",
-                      "author_name": "Hafiz Ibn Kathir",
-                      "slug": "en-tafsir-ibn-kathir",
-                      "language_name": "english",
-                      "translated_name": {
-                        "name": "Tafsir Ibn Kathir",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 169,
+                          "name": "Tafsir Ibn Kathir",
+                          "author_name": "Hafiz Ibn Kathir",
+                          "slug": "en-tafsir-ibn-kathir",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Tafsir Ibn Kathir",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "english_tafsir_resources": {
+                    "summary": "English tafsir resources",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 169,
+                          "name": "Tafsir Ibn Kathir",
+                          "author_name": "Hafiz Ibn Kathir",
+                          "slug": "en-tafsir-ibn-kathir",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Tafsir Ibn Kathir",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "arabic_tafsir_resources": {
+                    "summary": "Arabic tafsir resources",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 16,
+                          "name": "Tafsir al-Tabari",
+                          "author_name": "Imam al-Tabari",
+                          "slug": "tafsir-tabari",
+                          "language_name": "arabic",
+                          "translated_name": {
+                            "name": "Tafsir al-Tabari",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -9922,10 +11963,15 @@
                     }
                   }
                 },
-                "example": {
-                  "info": {
-                    "id": 169,
-                    "info": "<p>Tafsir Ibn Kathir is one of the most comprehensive classical commentaries, compiled in the 14th century by the Damascene scholar Ibn Kathir. It combines narration, legal analysis, and linguistic insights while cross-referencing Prophetic traditions.</p>"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "info": {
+                        "id": 169,
+                        "info": "<p>Tafsir Ibn Kathir is one of the most comprehensive classical commentaries, compiled in the 14th century by the Damascene scholar Ibn Kathir. It combines narration, legal analysis, and linguistic insights while cross-referencing Prophetic traditions.</p>"
+                      }
+                    }
                   }
                 }
               }
@@ -10056,11 +12102,16 @@
                     }
                   }
                 },
-                "example": {
-                  "recitation_styles": {
-                    "mujawwad": "Mujawwad is a melodic style of Holy Quran recitation",
-                    "murattal": "Murattal is at a slower pace, used for study and practice",
-                    "muallim": "Muallim is teaching style recitation of Holy Quran"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "recitation_styles": {
+                        "mujawwad": "Mujawwad is a melodic style of Holy Quran recitation",
+                        "murattal": "Murattal is at a slower pace, used for study and practice",
+                        "muallim": "Muallim is teaching style recitation of Holy Quran"
+                      }
+                    }
                   }
                 }
               }
@@ -10188,21 +12239,47 @@
                     }
                   }
                 },
-                "example": {
-                  "languages": [
-                    {
-                      "id": 38,
-                      "name": "English",
-                      "native_name": "English",
-                      "iso_code": "en",
-                      "direction": "ltr",
-                      "translations_count": 100,
-                      "translated_name": {
-                        "name": "English",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "languages": [
+                        {
+                          "id": 38,
+                          "name": "English",
+                          "native_name": "English",
+                          "iso_code": "en",
+                          "direction": "ltr",
+                          "translations_count": 100,
+                          "translated_name": {
+                            "name": "English",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "supported_languages": {
+                    "summary": "Supported content languages",
+                    "value": {
+                      "languages": [
+                        {
+                          "id": 38,
+                          "name": "English",
+                          "iso_code": "en",
+                          "native_name": "English",
+                          "direction": "ltr"
+                        },
+                        {
+                          "id": 174,
+                          "name": "Arabic",
+                          "iso_code": "ar",
+                          "native_name": "Arabic",
+                          "direction": "rtl"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -10345,53 +12422,58 @@
                     }
                   }
                 },
-                "example": {
-                  "chapter_infos": [
-                    {
-                      "id": 155,
-                      "name": "Hamza Roberto Piccardo",
-                      "author_name": "Hamza Roberto Piccardo",
-                      "slug": "hamza-roberto-piccardo-info",
-                      "language_name": "italian",
-                      "translated_name": {
-                        "name": "Hamza Roberto Piccardo",
-                        "language_name": "english"
-                      }
-                    },
-                    {
-                      "id": 63,
-                      "name": "Chapter Info",
-                      "author_name": "Sayyid Abul Ala Maududi",
-                      "slug": null,
-                      "language_name": "malayalam",
-                      "translated_name": {
-                        "name": "Chapter Info",
-                        "language_name": "english"
-                      }
-                    },
-                    {
-                      "id": 62,
-                      "name": "Chapter Info",
-                      "author_name": "Sayyid Abul Ala Maududi",
-                      "slug": null,
-                      "language_name": "tamil",
-                      "translated_name": {
-                        "name": "Chapter Info",
-                        "language_name": "english"
-                      }
-                    },
-                    {
-                      "id": 61,
-                      "name": "Chapter Info",
-                      "author_name": "Sayyid Abul Ala Maududi",
-                      "slug": null,
-                      "language_name": "urdu",
-                      "translated_name": {
-                        "name": "Chapter Info",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "chapter_infos": [
+                        {
+                          "id": 155,
+                          "name": "Hamza Roberto Piccardo",
+                          "author_name": "Hamza Roberto Piccardo",
+                          "slug": "hamza-roberto-piccardo-info",
+                          "language_name": "italian",
+                          "translated_name": {
+                            "name": "Hamza Roberto Piccardo",
+                            "language_name": "english"
+                          }
+                        },
+                        {
+                          "id": 63,
+                          "name": "Chapter Info",
+                          "author_name": "Sayyid Abul Ala Maududi",
+                          "slug": null,
+                          "language_name": "malayalam",
+                          "translated_name": {
+                            "name": "Chapter Info",
+                            "language_name": "english"
+                          }
+                        },
+                        {
+                          "id": 62,
+                          "name": "Chapter Info",
+                          "author_name": "Sayyid Abul Ala Maududi",
+                          "slug": null,
+                          "language_name": "tamil",
+                          "translated_name": {
+                            "name": "Chapter Info",
+                            "language_name": "english"
+                          }
+                        },
+                        {
+                          "id": 61,
+                          "name": "Chapter Info",
+                          "author_name": "Sayyid Abul Ala Maududi",
+                          "slug": null,
+                          "language_name": "urdu",
+                          "translated_name": {
+                            "name": "Chapter Info",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -10548,20 +12630,43 @@
                     }
                   }
                 },
-                "example": {
-                  "verse_media": [
-                    {
-                      "id": 12,
-                      "name": "Quranic Audio Lessons",
-                      "author_name": "Quran Foundation",
-                      "slug": "quranic-audio-lessons",
-                      "language_name": "english",
-                      "translated_name": {
-                        "name": "Quranic Audio Lessons",
-                        "language_name": "english"
-                      }
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verse_media": [
+                        {
+                          "id": 12,
+                          "name": "Quranic Audio Lessons",
+                          "author_name": "Quran Foundation",
+                          "slug": "quranic-audio-lessons",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Quranic Audio Lessons",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "verse_media_catalog": {
+                    "summary": "Verse media resource catalog",
+                    "value": {
+                      "verse_media": [
+                        {
+                          "id": 1,
+                          "name": "Verse images",
+                          "author_name": "Quran.Foundation",
+                          "slug": "verse-images",
+                          "language_name": "english",
+                          "translated_name": {
+                            "name": "Verse images",
+                            "language_name": "english"
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -10731,19 +12836,24 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -10914,19 +13024,24 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -11093,20 +13208,60 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "resource_id": 131,
-                      "text": "In the Name of Allah—the Most Compassionate, Most Merciful.",
-                      "verse_key": "1:1"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful.",
+                          "verse_key": "1:1"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": null,
-                    "total_pages": 1,
-                    "total_records": 1
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -11273,25 +13428,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215001,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215002,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215001,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215002,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -11458,25 +13653,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215101,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215102,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215101,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215102,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -11643,25 +13878,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215201,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215202,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215201,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215202,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -11828,25 +14103,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215301,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215302,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215301,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215302,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -12013,25 +14328,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215401,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215402,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215401,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215402,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -12198,25 +14553,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215501,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215502,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215501,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215502,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -12382,20 +14777,50 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215601,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215601,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": null,
-                    "total_pages": 1,
-                    "total_records": 1
+                  },
+                  "single_ayah_translation": {
+                    "summary": "Translation rows for one ayah",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 904212,
+                          "text": "Allah! There is no god except Him, the Ever-Living, All-Sustaining.",
+                          "verse_id": 255,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "2:255",
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42,
+                          "ruku_number": 35,
+                          "manzil_number": 1
+                        }
+                      ]
+                    }
                   }
                 }
               }
@@ -12562,20 +14987,58 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "resource_id": 169,
-                      "text": "Bismillah بِسْمِ اللَّـهِ is a verse of the Holy Qur'an",
-                      "verse_key": "1:1"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "resource_id": 169,
+                          "text": "Bismillah بِسْمِ اللَّـهِ is a verse of the Holy Qur'an",
+                          "verse_key": "1:1"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": null,
-                    "total_pages": 1,
-                    "total_records": 1
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -12742,23 +15205,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -12925,23 +15426,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -13108,23 +15647,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -13291,23 +15868,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -13474,23 +16089,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -13657,23 +16310,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -13870,28 +16561,54 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsir": {
-                    "verses": {
-                      "2:111": {
-                        "id": 118
-                      },
-                      "2:112": {
-                        "id": 119
-                      },
-                      "2:113": {
-                        "id": 120
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsir": {
+                        "verses": {
+                          "2:111": {
+                            "id": 118
+                          },
+                          "2:112": {
+                            "id": 119
+                          },
+                          "2:113": {
+                            "id": 120
+                          }
+                        },
+                        "resource_id": 168,
+                        "resource_name": "Ma'arif al-Qur'an",
+                        "language_id": 38,
+                        "slug": "en-tafsir-maarif-ul-quran",
+                        "translated_name": {
+                          "name": "Ma'arif al-Qur'an",
+                          "language_name": "english"
+                        },
+                        "text": "<p>…HTML tafsīr…</p>"
                       }
-                    },
-                    "resource_id": 168,
-                    "resource_name": "Ma'arif al-Qur'an",
-                    "language_id": 38,
-                    "slug": "en-tafsir-maarif-ul-quran",
-                    "translated_name": {
-                      "name": "Ma'arif al-Qur'an",
-                      "language_name": "english"
-                    },
-                    "text": "<p>…HTML tafsīr…</p>"
+                    }
+                  },
+                  "single_ayah_tafsir": {
+                    "summary": "Tafsir for one ayah",
+                    "value": {
+                      "tafsir": {
+                        "verses": {
+                          "1:1": {
+                            "id": 82641
+                          }
+                        },
+                        "resource_id": 169,
+                        "resource_name": "Tafsir Ibn Kathir",
+                        "language_id": 38,
+                        "slug": "tafsir-ibn-kathir",
+                        "translated_name": {
+                          "name": "Tafsir Ibn Kathir",
+                          "language_name": "english"
+                        },
+                        "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>"
+                      }
+                    }
                   }
                 }
               }
@@ -14024,17 +16741,22 @@
                     }
                   }
                 },
-                "example": {
-                  "juz": {
-                    "id": 1,
-                    "juz_number": 1,
-                    "verse_mapping": {
-                      "1": "1-7",
-                      "2": "1-141"
-                    },
-                    "first_verse_id": 1,
-                    "last_verse_id": 148,
-                    "verses_count": 148
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "juz": {
+                        "id": 1,
+                        "juz_number": 1,
+                        "verse_mapping": {
+                          "1": "1-7",
+                          "2": "1-141"
+                        },
+                        "first_verse_id": 1,
+                        "last_verse_id": 148,
+                        "verses_count": 148
+                      }
+                    }
                   }
                 }
               }
@@ -14152,22 +16874,27 @@
                     }
                   }
                 },
-                "example": {
-                  "hizbs": [
-                    {
-                      "id": 1,
-                      "hizb_number": 1,
-                      "verse_mapping": {
-                        "1": "1-77",
-                        "2": "78-141",
-                        "3": "142-176",
-                        "4": "177-286"
-                      },
-                      "first_verse_id": 1,
-                      "last_verse_id": 286,
-                      "verses_count": 286
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "hizbs": [
+                        {
+                          "id": 1,
+                          "hizb_number": 1,
+                          "verse_mapping": {
+                            "1": "1-77",
+                            "2": "78-141",
+                            "3": "142-176",
+                            "4": "177-286"
+                          },
+                          "first_verse_id": 1,
+                          "last_verse_id": 286,
+                          "verses_count": 286
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -14291,19 +17018,24 @@
                     }
                   }
                 },
-                "example": {
-                  "hizb": {
-                    "id": 1,
-                    "hizb_number": 1,
-                    "verse_mapping": {
-                      "1": "1-77",
-                      "2": "78-141",
-                      "3": "142-176",
-                      "4": "177-286"
-                    },
-                    "first_verse_id": 1,
-                    "last_verse_id": 286,
-                    "verses_count": 286
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "hizb": {
+                        "id": 1,
+                        "hizb_number": 1,
+                        "verse_mapping": {
+                          "1": "1-77",
+                          "2": "78-141",
+                          "3": "142-176",
+                          "4": "177-286"
+                        },
+                        "first_verse_id": 1,
+                        "last_verse_id": 286,
+                        "verses_count": 286
+                      }
+                    }
                   }
                 }
               }
@@ -14421,20 +17153,25 @@
                     }
                   }
                 },
-                "example": {
-                  "rub_el_hizbs": [
-                    {
-                      "id": 1,
-                      "rub_el_hizb_number": 1,
-                      "verse_mapping": {
-                        "1": "1-26",
-                        "2": "27-43"
-                      },
-                      "first_verse_id": 1,
-                      "last_verse_id": 43,
-                      "verses_count": 43
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "rub_el_hizbs": [
+                        {
+                          "id": 1,
+                          "rub_el_hizb_number": 1,
+                          "verse_mapping": {
+                            "1": "1-26",
+                            "2": "27-43"
+                          },
+                          "first_verse_id": 1,
+                          "last_verse_id": 43,
+                          "verses_count": 43
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -14558,17 +17295,22 @@
                     }
                   }
                 },
-                "example": {
-                  "rub_el_hizb": {
-                    "id": 1,
-                    "rub_el_hizb_number": 1,
-                    "verse_mapping": {
-                      "1": "1-26",
-                      "2": "27-43"
-                    },
-                    "first_verse_id": 1,
-                    "last_verse_id": 43,
-                    "verses_count": 43
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "rub_el_hizb": {
+                        "id": 1,
+                        "rub_el_hizb_number": 1,
+                        "verse_mapping": {
+                          "1": "1-26",
+                          "2": "27-43"
+                        },
+                        "first_verse_id": 1,
+                        "last_verse_id": 43,
+                        "verses_count": 43
+                      }
+                    }
                   }
                 }
               }
@@ -14686,20 +17428,25 @@
                     }
                   }
                 },
-                "example": {
-                  "rukus": [
-                    {
-                      "id": 1,
-                      "ruku_number": 1,
-                      "surah_ruku_number": 1,
-                      "verse_mapping": {
-                        "1": "1-7"
-                      },
-                      "first_verse_id": 1,
-                      "last_verse_id": 7,
-                      "verses_count": 7
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "rukus": [
+                        {
+                          "id": 1,
+                          "ruku_number": 1,
+                          "surah_ruku_number": 1,
+                          "verse_mapping": {
+                            "1": "1-7"
+                          },
+                          "first_verse_id": 1,
+                          "last_verse_id": 7,
+                          "verses_count": 7
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -14823,17 +17570,22 @@
                     }
                   }
                 },
-                "example": {
-                  "ruku": {
-                    "id": 1,
-                    "ruku_number": 1,
-                    "surah_ruku_number": 1,
-                    "verse_mapping": {
-                      "1": "1-7"
-                    },
-                    "first_verse_id": 1,
-                    "last_verse_id": 7,
-                    "verses_count": 7
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "ruku": {
+                        "id": 1,
+                        "ruku_number": 1,
+                        "surah_ruku_number": 1,
+                        "verse_mapping": {
+                          "1": "1-7"
+                        },
+                        "first_verse_id": 1,
+                        "last_verse_id": 7,
+                        "verses_count": 7
+                      }
+                    }
                   }
                 }
               }
@@ -14951,20 +17703,25 @@
                     }
                   }
                 },
-                "example": {
-                  "manzils": [
-                    {
-                      "id": 1,
-                      "manzil_number": 1,
-                      "verse_mapping": {
-                        "1": "1-148",
-                        "2": "1-152"
-                      },
-                      "first_verse_id": 1,
-                      "last_verse_id": 260,
-                      "verses_count": 260
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "manzils": [
+                        {
+                          "id": 1,
+                          "manzil_number": 1,
+                          "verse_mapping": {
+                            "1": "1-148",
+                            "2": "1-152"
+                          },
+                          "first_verse_id": 1,
+                          "last_verse_id": 260,
+                          "verses_count": 260
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -15088,17 +17845,22 @@
                     }
                   }
                 },
-                "example": {
-                  "manzil": {
-                    "id": 1,
-                    "manzil_number": 1,
-                    "verse_mapping": {
-                      "1": "1-148",
-                      "2": "1-152"
-                    },
-                    "first_verse_id": 1,
-                    "last_verse_id": 260,
-                    "verses_count": 260
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "manzil": {
+                        "id": 1,
+                        "manzil_number": 1,
+                        "verse_mapping": {
+                          "1": "1-148",
+                          "2": "1-152"
+                        },
+                        "first_verse_id": 1,
+                        "last_verse_id": 260,
+                        "verses_count": 260
+                      }
+                    }
                   }
                 }
               }
@@ -15221,11 +17983,16 @@
                     }
                   }
                 },
-                "example": {
-                  "foot_note": {
-                    "id": 1,
-                    "text": "Some manuscripts record an additional marginal explanation for this verse.",
-                    "language_name": "english"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "foot_note": {
+                        "id": 1,
+                        "text": "Some manuscripts record an additional marginal explanation for this verse.",
+                        "language_name": "english"
+                      }
+                    }
                   }
                 }
               }
@@ -15529,28 +18296,69 @@
                 "schema": {
                   "$ref": "#/components/schemas/FeedResponseDto"
                 },
-                "example": {
-                  "total": 1,
-                  "currentPage": 1,
-                  "limit": 20,
-                  "pages": 1,
-                  "data": [
-                    {
-                      "id": 101,
-                      "authorId": "user-123",
-                      "body": "Reflection text",
-                      "createdAt": "2026-04-01T12:00:00.000Z",
-                      "updatedAt": "2026-04-01T12:00:00.000Z",
-                      "publishedAt": "2026-04-01T12:00:00.000Z",
-                      "commentsCount": 2,
-                      "likesCount": 5,
-                      "viewsCount": 20,
-                      "languageName": "english",
-                      "roomId": 1,
-                      "postTypeId": 1,
-                      "postTypeName": "reflection"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "total": 1,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 1,
+                      "data": [
+                        {
+                          "id": 101,
+                          "authorId": "user-123",
+                          "body": "Reflection text",
+                          "createdAt": "2026-04-01T12:00:00.000Z",
+                          "updatedAt": "2026-04-01T12:00:00.000Z",
+                          "publishedAt": "2026-04-01T12:00:00.000Z",
+                          "commentsCount": 2,
+                          "likesCount": 5,
+                          "viewsCount": 20,
+                          "languageName": "english",
+                          "roomId": 1,
+                          "postTypeId": 1,
+                          "postTypeName": "reflection"
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "feed_with_posts": {
+                    "summary": "Feed page with reflection posts",
+                    "value": {
+                      "total": 1,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 1,
+                      "data": [
+                        {
+                          "id": 101,
+                          "authorId": "user-123",
+                          "body": "Reflection text",
+                          "createdAt": "2026-04-01T12:00:00.000Z",
+                          "updatedAt": "2026-04-01T12:00:00.000Z",
+                          "publishedAt": "2026-04-01T12:00:00.000Z",
+                          "commentsCount": 2,
+                          "likesCount": 5,
+                          "viewsCount": 20,
+                          "languageName": "english",
+                          "roomId": 1,
+                          "postTypeId": 1,
+                          "postTypeName": "reflection"
+                        }
+                      ]
+                    }
+                  },
+                  "empty_feed_page": {
+                    "summary": "Feed page with no matching posts",
+                    "value": {
+                      "total": 0,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 0,
+                      "data": []
+                    }
+                  }
                 }
               }
             }
@@ -15601,20 +18409,25 @@
                 "schema": {
                   "$ref": "#/components/schemas/PostSerialized"
                 },
-                "example": {
-                  "id": 101,
-                  "authorId": "user-123",
-                  "body": "Reflection text",
-                  "createdAt": "2026-04-01T12:00:00.000Z",
-                  "updatedAt": "2026-04-01T12:00:00.000Z",
-                  "publishedAt": "2026-04-01T12:00:00.000Z",
-                  "commentsCount": 2,
-                  "likesCount": 5,
-                  "viewsCount": 20,
-                  "languageName": "english",
-                  "roomId": 1,
-                  "postTypeId": 1,
-                  "postTypeName": "reflection"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "id": 101,
+                      "authorId": "user-123",
+                      "body": "Reflection text",
+                      "createdAt": "2026-04-01T12:00:00.000Z",
+                      "updatedAt": "2026-04-01T12:00:00.000Z",
+                      "publishedAt": "2026-04-01T12:00:00.000Z",
+                      "commentsCount": 2,
+                      "likesCount": 5,
+                      "viewsCount": 20,
+                      "languageName": "english",
+                      "roomId": 1,
+                      "postTypeId": 1,
+                      "postTypeName": "reflection"
+                    }
+                  }
                 }
               }
             }
@@ -15716,28 +18529,33 @@
                 "schema": {
                   "$ref": "#/components/schemas/FeedResponseDto"
                 },
-                "example": {
-                  "total": 1,
-                  "currentPage": 1,
-                  "limit": 20,
-                  "pages": 1,
-                  "data": [
-                    {
-                      "id": 101,
-                      "authorId": "user-123",
-                      "body": "Reflection text",
-                      "createdAt": "2026-04-01T12:00:00.000Z",
-                      "updatedAt": "2026-04-01T12:00:00.000Z",
-                      "publishedAt": "2026-04-01T12:00:00.000Z",
-                      "commentsCount": 2,
-                      "likesCount": 5,
-                      "viewsCount": 20,
-                      "languageName": "english",
-                      "roomId": 1,
-                      "postTypeId": 1,
-                      "postTypeName": "reflection"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "total": 1,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 1,
+                      "data": [
+                        {
+                          "id": 101,
+                          "authorId": "user-123",
+                          "body": "Reflection text",
+                          "createdAt": "2026-04-01T12:00:00.000Z",
+                          "updatedAt": "2026-04-01T12:00:00.000Z",
+                          "publishedAt": "2026-04-01T12:00:00.000Z",
+                          "commentsCount": 2,
+                          "likesCount": 5,
+                          "viewsCount": 20,
+                          "languageName": "english",
+                          "roomId": 1,
+                          "postTypeId": 1,
+                          "postTypeName": "reflection"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -15811,23 +18629,59 @@
                 "schema": {
                   "$ref": "#/components/schemas/PostCommentsResponse"
                 },
-                "example": {
-                  "total": 1,
-                  "currentPage": 1,
-                  "limit": 20,
-                  "pages": 1,
-                  "comments": [
-                    {
-                      "id": 501,
-                      "postId": 101,
-                      "authorId": "user-456",
-                      "parentId": 0,
-                      "isPrivate": false,
-                      "body": "Comment text",
-                      "createdAt": "2026-04-01T13:00:00.000Z",
-                      "updatedAt": "2026-04-01T13:00:00.000Z"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "total": 1,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 1,
+                      "comments": [
+                        {
+                          "id": 501,
+                          "postId": 101,
+                          "authorId": "user-456",
+                          "parentId": 0,
+                          "isPrivate": false,
+                          "body": "Comment text",
+                          "createdAt": "2026-04-01T13:00:00.000Z",
+                          "updatedAt": "2026-04-01T13:00:00.000Z"
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "comments_page": {
+                    "summary": "Paginated comments for a post",
+                    "value": {
+                      "total": 1,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 1,
+                      "comments": [
+                        {
+                          "id": 501,
+                          "postId": 101,
+                          "authorId": "user-456",
+                          "parentId": 0,
+                          "isPrivate": false,
+                          "body": "Comment text",
+                          "createdAt": "2026-04-01T13:00:00.000Z",
+                          "updatedAt": "2026-04-01T13:00:00.000Z"
+                        }
+                      ]
+                    }
+                  },
+                  "no_comments": {
+                    "summary": "Post with no comments",
+                    "value": {
+                      "total": 0,
+                      "currentPage": 1,
+                      "limit": 20,
+                      "pages": 0,
+                      "comments": []
+                    }
+                  }
                 }
               }
             }
@@ -15881,20 +18735,50 @@
                 "schema": {
                   "$ref": "#/components/schemas/PostAllCommentsResponse"
                 },
-                "example": {
-                  "total": 1,
-                  "comments": [
-                    {
-                      "id": 501,
-                      "postId": 101,
-                      "authorId": "user-456",
-                      "parentId": 0,
-                      "isPrivate": false,
-                      "body": "Comment text",
-                      "createdAt": "2026-04-01T13:00:00.000Z",
-                      "updatedAt": "2026-04-01T13:00:00.000Z"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "total": 1,
+                      "comments": [
+                        {
+                          "id": 501,
+                          "postId": 101,
+                          "authorId": "user-456",
+                          "parentId": 0,
+                          "isPrivate": false,
+                          "body": "Comment text",
+                          "createdAt": "2026-04-01T13:00:00.000Z",
+                          "updatedAt": "2026-04-01T13:00:00.000Z"
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "all_comments_flat_list": {
+                    "summary": "All comments for a post",
+                    "value": {
+                      "total": 1,
+                      "comments": [
+                        {
+                          "id": 501,
+                          "postId": 101,
+                          "authorId": "user-456",
+                          "parentId": 0,
+                          "isPrivate": false,
+                          "body": "Comment text",
+                          "createdAt": "2026-04-01T13:00:00.000Z",
+                          "updatedAt": "2026-04-01T13:00:00.000Z"
+                        }
+                      ]
+                    }
+                  },
+                  "no_comments": {
+                    "summary": "Post with no comments",
+                    "value": {
+                      "total": 0,
+                      "comments": []
+                    }
+                  }
                 }
               }
             }
@@ -15962,23 +18846,49 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "id": 43,
-                      "chapter_id": 22,
-                      "file_size": 19779712,
-                      "format": "mp3",
-                      "audio_url": "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee//022.mp3"
-                    },
-                    {
-                      "id": 87,
-                      "chapter_id": 44,
-                      "file_size": 6453376,
-                      "format": "mp3",
-                      "audio_url": "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee//044.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "id": 43,
+                          "chapter_id": 22,
+                          "file_size": 19779712,
+                          "format": "mp3",
+                          "audio_url": "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee//022.mp3"
+                        },
+                        {
+                          "id": 87,
+                          "chapter_id": 44,
+                          "file_size": 6453376,
+                          "format": "mp3",
+                          "audio_url": "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee//044.mp3"
+                        }
+                      ]
                     }
-                  ]
+                  },
+                  "available_chapter_files": {
+                    "summary": "Chapter-level audio files for a reciter",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "id": 43,
+                          "chapter_id": 22,
+                          "file_size": 19779712,
+                          "format": "mp3",
+                          "audio_url": "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee/022.mp3"
+                        },
+                        {
+                          "id": 87,
+                          "chapter_id": 44,
+                          "file_size": 6453376,
+                          "format": "mp3",
+                          "audio_url": "https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee/044.mp3"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -16447,59 +19357,154 @@
                     }
                   }
                 },
-                "example": {
-                  "verses": [
-                    {
-                      "id": 1,
-                      "verse_number": 1,
-                      "page_number": 1,
-                      "verse_key": "1:1",
-                      "juz_number": 1,
-                      "hizb_number": 1,
-                      "rub_el_hizb_number": 1,
-                      "sajdah_type": null,
-                      "sajdah_number": null,
-                      "words": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "verses": [
                         {
                           "id": 1,
-                          "position": 1,
-                          "audio_url": "wbw/001_001_001.mp3",
-                          "char_type_name": "word",
-                          "line_number": 2,
+                          "verse_number": 1,
                           "page_number": 1,
-                          "code_v1": "&#xfb51;",
-                          "translation": {
-                            "text": "In (the) name",
-                            "language_name": "english"
-                          },
-                          "transliteration": {
-                            "text": "bis'mi",
-                            "language_name": "english"
-                          }
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
                         }
                       ],
-                      "translations": [
-                        {
-                          "resource_id": 131,
-                          "text": "In the Name of Allah—the Most Compassionate, Most Merciful."
-                        }
-                      ],
-                      "tafsirs": [
-                        {
-                          "id": 82641,
-                          "language_name": "english",
-                          "name": "Tafsir Ibn Kathir",
-                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
-                        }
-                      ]
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 1,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 7,
-                    "total_records": 7
+                  },
+                  "compact_fields": {
+                    "summary": "Compact verse fields for navigation views",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 255,
+                          "chapter_id": 2,
+                          "verse_number": 255,
+                          "verse_key": "2:255",
+                          "verse_index": 262,
+                          "juz_number": 3,
+                          "hizb_number": 5,
+                          "rub_el_hizb_number": 19,
+                          "page_number": 42
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": null,
+                        "total_pages": 1,
+                        "total_records": 1
+                      }
+                    }
+                  },
+                  "with_words_translation_tafsir_audio": {
+                    "summary": "Verse payload with words, translation, tafsir, and audio",
+                    "value": {
+                      "verses": [
+                        {
+                          "id": 1,
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "page_number": 1,
+                          "verse_key": "1:1",
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "sajdah_type": null,
+                          "sajdah_number": null,
+                          "audio": {
+                            "verse_key": "1:1",
+                            "url": "https://verses.quran.foundation/Alafasy/mp3/001001.mp3"
+                          },
+                          "words": [
+                            {
+                              "id": 1,
+                              "position": 1,
+                              "audio_url": "wbw/001_001_001.mp3",
+                              "char_type_name": "word",
+                              "line_number": 2,
+                              "page_number": 1,
+                              "code_v1": "&#xfb51;",
+                              "translation": {
+                                "text": "In (the) name",
+                                "language_name": "english"
+                              },
+                              "transliteration": {
+                                "text": "bis'mi",
+                                "language_name": "english"
+                              }
+                            }
+                          ],
+                          "translations": [
+                            {
+                              "resource_id": 131,
+                              "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                              "text": "In the Name of Allah?the Most Compassionate, Most Merciful."
+                            }
+                          ],
+                          "tafsirs": [
+                            {
+                              "id": 82641,
+                              "resource_id": 169,
+                              "language_name": "english",
+                              "name": "Tafsir Ibn Kathir",
+                              "text": "<h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>"
+                            }
+                          ]
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -16614,25 +19619,65 @@
                     }
                   }
                 },
-                "example": {
-                  "translations": [
-                    {
-                      "id": 215201,
-                      "resource_id": 20,
-                      "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
-                    },
-                    {
-                      "id": 215202,
-                      "resource_id": 20,
-                      "text": "All praise is for Allah, Lord of all worlds."
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "translations": [
+                        {
+                          "id": 215201,
+                          "resource_id": 20,
+                          "text": "In the Name of Allah-the Most Compassionate, Most Merciful."
+                        },
+                        {
+                          "id": 215202,
+                          "resource_id": 20,
+                          "text": "All praise is for Allah, Lord of all worlds."
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_translation_rows": {
+                    "summary": "Paginated translation rows",
+                    "value": {
+                      "translations": [
+                        {
+                          "resource_id": 131,
+                          "resource_name": "Dr. Mustafa Khattab, the Clear Quran",
+                          "id": 903958,
+                          "text": "In the Name of Allah?the Most Compassionate, Most Merciful.",
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "language_name": "english",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "foot_notes": {
+                            "1": "Some editions include a translator footnote here."
+                          }
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -16747,23 +19792,61 @@
                     }
                   }
                 },
-                "example": {
-                  "tafsirs": [
-                    {
-                      "id": 82641,
-                      "resource_id": 169,
-                      "verse_key": "1:1",
-                      "language_id": 38,
-                      "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
-                      "slug": "tafsir-ibn-kathir"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_key": "1:1",
+                          "language_id": 38,
+                          "text": "<h2 class=\"title\">Which was revealed in Makkah</h2><h2 class=\"title\">The Meaning of Al-Fatihah and its Various Names</h2>",
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 50,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 12,
+                        "total_records": 600
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 50,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 12,
-                    "total_records": 600
+                  },
+                  "paginated_tafsir_rows": {
+                    "summary": "Paginated tafsir rows",
+                    "value": {
+                      "tafsirs": [
+                        {
+                          "id": 82641,
+                          "resource_id": 169,
+                          "verse_id": 1,
+                          "language_id": 38,
+                          "text": "<p>Bismillah is a verse of the Holy Qur'an.</p>",
+                          "language_name": "english",
+                          "resource_name": "Tafsir Ibn Kathir",
+                          "verse_key": "1:1",
+                          "chapter_id": 1,
+                          "verse_number": 1,
+                          "juz_number": 1,
+                          "hizb_number": 1,
+                          "rub_el_hizb_number": 1,
+                          "page_number": 1,
+                          "ruku_number": 1,
+                          "manzil_number": 1,
+                          "slug": "tafsir-ibn-kathir"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 1,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 7,
+                        "total_records": 7
+                      }
+                    }
                   }
                 }
               }
@@ -16882,27 +19965,32 @@
                     }
                   }
                 },
-                "example": {
-                  "audio_files": [
-                    {
-                      "verse_key": "1:1",
-                      "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
-                    },
-                    {
-                      "verse_key": "1:2",
-                      "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
-                    },
-                    {
-                      "verse_key": "1:3",
-                      "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "audio_files": [
+                        {
+                          "verse_key": "1:1",
+                          "url": "AbdulBaset/Mujawwad/mp3/001001.mp3"
+                        },
+                        {
+                          "verse_key": "1:2",
+                          "url": "AbdulBaset/Mujawwad/mp3/001002.mp3"
+                        },
+                        {
+                          "verse_key": "1:3",
+                          "url": "AbdulBaset/Mujawwad/mp3/001003.mp3"
+                        }
+                      ],
+                      "pagination": {
+                        "per_page": 10,
+                        "current_page": 1,
+                        "next_page": 2,
+                        "total_pages": 15,
+                        "total_records": 148
+                      }
                     }
-                  ],
-                  "pagination": {
-                    "per_page": 10,
-                    "current_page": 1,
-                    "next_page": 2,
-                    "total_pages": 15,
-                    "total_records": 148
                   }
                 }
               }
@@ -16996,36 +20084,82 @@
                 "schema": {
                   "$ref": "#/components/schemas/AnswersByAyahResponse"
                 },
-                "example": {
-                  "questions": [
-                    {
-                      "id": "question-1",
-                      "body": "What is the context of this ayah?",
-                      "type": "CLARIFICATION",
-                      "ranges": [
-                        "2:255"
-                      ],
-                      "surah": 2,
-                      "theme": [
-                        "Faith"
-                      ],
-                      "references": [
-                        "Tafsir al-Tabari"
-                      ],
-                      "language": "en",
-                      "status": "Published",
-                      "answers": [
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "questions": [
                         {
-                          "id": "answer-1",
-                          "body": "This ayah is known as Ayat al-Kursi.",
-                          "answeredBy": "Scholar",
+                          "id": "question-1",
+                          "body": "What is the context of this ayah?",
+                          "type": "CLARIFICATION",
+                          "ranges": [
+                            "2:255"
+                          ],
+                          "surah": 2,
+                          "theme": [
+                            "Faith"
+                          ],
+                          "references": [
+                            "Tafsir al-Tabari"
+                          ],
+                          "language": "en",
                           "status": "Published",
-                          "language": "en"
+                          "answers": [
+                            {
+                              "id": "answer-1",
+                              "body": "This ayah is known as Ayat al-Kursi.",
+                              "answeredBy": "Scholar",
+                              "status": "Published",
+                              "language": "en"
+                            }
+                          ]
                         }
-                      ]
+                      ],
+                      "totalCount": 1
                     }
-                  ],
-                  "totalCount": 1
+                  },
+                  "questions_found": {
+                    "summary": "Ayah with published answers",
+                    "value": {
+                      "questions": [
+                        {
+                          "id": "question-1",
+                          "body": "What is the context of this ayah?",
+                          "type": "CLARIFICATION",
+                          "ranges": [
+                            "2:255"
+                          ],
+                          "surah": 2,
+                          "theme": [
+                            "Faith"
+                          ],
+                          "references": [
+                            "Tafsir al-Tabari"
+                          ],
+                          "language": "en",
+                          "status": "Published",
+                          "answers": [
+                            {
+                              "id": "answer-1",
+                              "body": "This ayah is known as Ayat al-Kursi.",
+                              "answeredBy": "Scholar",
+                              "status": "Published",
+                              "language": "en"
+                            }
+                          ]
+                        }
+                      ],
+                      "totalCount": 1
+                    }
+                  },
+                  "no_questions": {
+                    "summary": "Ayah with no answers",
+                    "value": {
+                      "questions": [],
+                      "totalCount": 0
+                    }
+                  }
                 }
               }
             }
@@ -17087,31 +20221,36 @@
                 "schema": {
                   "$ref": "#/components/schemas/AnswersQuestionDto"
                 },
-                "example": {
-                  "id": "question-1",
-                  "body": "What is the context of this ayah?",
-                  "type": "CLARIFICATION",
-                  "ranges": [
-                    "2:255"
-                  ],
-                  "surah": 2,
-                  "theme": [
-                    "Faith"
-                  ],
-                  "references": [
-                    "Tafsir al-Tabari"
-                  ],
-                  "language": "en",
-                  "status": "Published",
-                  "answers": [
-                    {
-                      "id": "answer-1",
-                      "body": "This ayah is known as Ayat al-Kursi.",
-                      "answeredBy": "Scholar",
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "id": "question-1",
+                      "body": "What is the context of this ayah?",
+                      "type": "CLARIFICATION",
+                      "ranges": [
+                        "2:255"
+                      ],
+                      "surah": 2,
+                      "theme": [
+                        "Faith"
+                      ],
+                      "references": [
+                        "Tafsir al-Tabari"
+                      ],
+                      "language": "en",
                       "status": "Published",
-                      "language": "en"
+                      "answers": [
+                        {
+                          "id": "answer-1",
+                          "body": "This ayah is known as Ayat al-Kursi.",
+                          "answeredBy": "Scholar",
+                          "status": "Published",
+                          "language": "en"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -17191,19 +20330,55 @@
                 "schema": {
                   "$ref": "#/components/schemas/AnswersCountWithinRangeResponse"
                 },
-                "example": {
-                  "2:255": {
-                    "types": {
-                      "CLARIFICATION": 1,
-                      "TAFSIR": 1
-                    },
-                    "total": 2
+                "examples": {
+                  "default_success": {
+                    "summary": "Successful response",
+                    "value": {
+                      "2:255": {
+                        "types": {
+                          "CLARIFICATION": 1,
+                          "TAFSIR": 1
+                        },
+                        "total": 2
+                      },
+                      "2:256": {
+                        "types": {
+                          "TAFSIR": 1
+                        },
+                        "total": 1
+                      }
+                    }
                   },
-                  "2:256": {
-                    "types": {
-                      "TAFSIR": 1
-                    },
-                    "total": 1
+                  "range_with_answer_counts": {
+                    "summary": "Answer counts grouped by ayah and type",
+                    "value": {
+                      "2:255": {
+                        "types": {
+                          "CLARIFICATION": 1,
+                          "TAFSIR": 1
+                        },
+                        "total": 2
+                      },
+                      "2:256": {
+                        "types": {
+                          "TAFSIR": 1
+                        },
+                        "total": 1
+                      }
+                    }
+                  },
+                  "range_with_no_answers": {
+                    "summary": "Verse range with no answers",
+                    "value": {
+                      "1:1": {
+                        "types": {},
+                        "total": 0
+                      },
+                      "1:2": {
+                        "types": {},
+                        "total": 0
+                      }
+                    }
                   }
                 }
               }
@@ -17371,6 +20546,18 @@
                             "unavailable_reason": null
                           }
                         ]
+                      }
+                    }
+                  },
+                  "no_changes_page": {
+                    "summary": "No resource changes available",
+                    "value": {
+                      "sync": {
+                        "sync_until_sequence": 98240,
+                        "has_more": false,
+                        "next_page_url": null,
+                        "next_sync_token": "opaque-next-sync-token",
+                        "mutations": []
                       }
                     }
                   }


### PR DESCRIPTION
Split out from PR #167 so Content API response examples can be reviewed independently.

Scope:
- Updates `openAPI/content/v4.json` only.
- Normalizes Content API JSON response examples into named OpenAPI `examples` blocks where appropriate.
- Adds broader 200-response variants across chapters, verses, Quran text, translations, tafsirs, resources, audio, Quran Reflect, Hadith, Answers, and sync/snapshot flows.
- Keeps generated API docs churn out of the PR diff.

Coverage:
- All 95 Content API 200 JSON responses have named examples.
- 66 Content API 200 JSON responses have multiple examples.
- No Content API JSON responses are missing examples.

Validation:
- Parsed `openAPI/content/v4.json` with Node.
- Ran direct Content response-example coverage validation.
- `git diff --check`
- `npx docusaurus build`
- `yarn re-gen`, then removed generated docs churn from the diff.
- `yarn postbuild:seo`
- `yarn typecheck`
- Cloudflare Pages passed on commit `317f863`.

Note:
- `yarn test` is not usable on this branch because the current `main` branch has no files matching `tests/**/*.test.cjs`, so Node exits before running tests.