### PR TITLE
docs: add Search API response examples

### DIFF
--- a/openAPI/search/v1.json
+++ b/openAPI/search/v1.json
@@ -135,18 +135,155 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SearchResponseDto"
+                },
+                "examples": {
+                  "advanced_results": {
+                    "summary": "Advanced search with verse and navigation results",
+                    "value": {
+                      "pagination": {
+                        "current_page": 1,
+                        "next_page": 2,
+                        "per_page": 10,
+                        "total_pages": 10,
+                        "total_records": 100
+                      },
+                      "result": {
+                        "navigation": [
+                          {
+                            "result_type": "surah",
+                            "key": 1,
+                            "name": "Al-Fatihah",
+                            "isArabic": false
+                          },
+                          {
+                            "result_type": "page",
+                            "key": 255,
+                            "name": "Page 255",
+                            "isArabic": false
+                          }
+                        ],
+                        "verses": [
+                          {
+                            "result_type": "ayah",
+                            "key": "1:1",
+                            "name": "In the name of Allah, the Most Merciful",
+                            "isArabic": false
+                          },
+                          {
+                            "result_type": "ayah",
+                            "key": "2:163",
+                            "name": "And your god is one God",
+                            "isArabic": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "no_results": {
+                    "summary": "Search completed with no matching results",
+                    "value": {
+                      "pagination": {
+                        "current_page": 1,
+                        "next_page": null,
+                        "per_page": 10,
+                        "total_pages": 0,
+                        "total_records": 0
+                      },
+                      "result": {
+                        "navigation": [],
+                        "verses": []
+                      }
+                    }
+                  },
+                  "quick_navigation": {
+                    "summary": "Quick mode command-bar style navigation results",
+                    "value": {
+                      "pagination": {
+                        "current_page": 1,
+                        "next_page": null,
+                        "per_page": 20,
+                        "total_pages": 1,
+                        "total_records": 2
+                      },
+                      "result": {
+                        "navigation": [
+                          {
+                            "result_type": "surah",
+                            "key": 36,
+                            "name": "Ya-Sin",
+                            "isArabic": false
+                          },
+                          {
+                            "result_type": "juz",
+                            "key": 30,
+                            "name": "Juz 30",
+                            "isArabic": false
+                          }
+                        ],
+                        "verses": []
+                      }
+                    }
+                  }
                 }
               }
             }
           },
           "400": {
-            "description": "Invalid search parameters - check required fields mode and query"
+            "description": "Invalid search parameters - check required fields mode and query",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchErrorResponseDto"
+                },
+                "examples": {
+                  "invalid_request": {
+                    "summary": "Invalid search parameters - check required fields mode and query",
+                    "value": {
+                      "status": 400,
+                      "error": "Bad Request"
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized - missing or invalid x-auth-token header"
+            "description": "Unauthorized - missing or invalid x-auth-token header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchErrorResponseDto"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "summary": "Unauthorized - missing or invalid x-auth-token header",
+                    "value": {
+                      "status": 401,
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden - token does not have the required \"search\" scope"
+            "description": "Forbidden - token does not have the required \"search\" scope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchErrorResponseDto"
+                },
+                "examples": {
+                  "forbidden": {
+                    "summary": "Forbidden - token does not have the required \"search\" scope",
+                    "value": {
+                      "status": 403,
+                      "error": "Forbidden"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -363,6 +500,34 @@
           "pagination",
           "result"
         ]
+      },
+      "SearchErrorResponseDto": {
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "status": {
+            "type": "integer",
+            "example": 400
+          },
+          "error": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "example": "Bad Request"
+          }
+        },
+        "additionalProperties": false
       }
     }
   },


### PR DESCRIPTION
Split out from PR #167 so Search API response examples can be reviewed independently.

Scope:
- Adds Search 200 response examples for advanced results, no results, and quick navigation.
- Adds documented JSON content/examples for common 400, 401, and 403 responses.
- Adds a Search error response schema matching the service error envelope.

Local validation:
- Parsed `openAPI/search/v1.json` with Node.
- Checked every Search JSON response has a top-level example.
- `git diff --check`

Hosted validation:
- Cloudflare Pages passed.