### PR TITLE
docs: update Python SDK install path

### DIFF
--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -13,7 +13,7 @@ We provide official SDKs to help you integrate the Quran.Foundation API into you
 | Language                    | Package                                     | Status    |
 | --------------------------- | ------------------------------------------- | --------- |
 | **JavaScript / TypeScript** | [`@quranjs/api`](/docs/sdk/javascript)      | Available |
-| **Python**                  | [`quran-foundation-api`](/docs/sdk/python)  | Preview   |
+| **Python**                  | [`quran-foundation-api`](/docs/sdk/python)  | Available |
 | Swift                       | Coming soon                                 | Planned   |
 | Kotlin                      | Coming soon                                 | Planned   |
 
@@ -22,7 +22,7 @@ We provide official SDKs to help you integrate the Quran.Foundation API into you
 Choose your language to get started:
 
 - [JavaScript / TypeScript SDK](/docs/sdk/javascript) - Full-featured SDK for Node.js and browsers
-- [Python SDK](/docs/sdk/python) - Preview SDK for server-side Python apps, jobs, scripts, and AI workflows
+- [Python SDK](/docs/sdk/python) - SDK for server-side Python apps, jobs, scripts, and AI workflows
 
 ## Why Use an SDK?
 

--- a/docs/sdk/python/index.mdx
+++ b/docs/sdk/python/index.mdx
@@ -7,21 +7,13 @@ sidebar_position: 2
 
 # Python SDK
 
-The Python SDK is a preview package for server-side Python applications, scripts, jobs, notebooks, and AI workflows. It imports as `quran_foundation` and uses the package name `quran-foundation-api`.
+The Python SDK is the official package for server-side Python applications, scripts, jobs, notebooks, and AI workflows. It is published on PyPI as [`quran-foundation-api`](https://pypi.org/project/quran-foundation-api/) and imports as `quran_foundation`.
 
 Use it from trusted server-side environments. Do not expose `client_secret`, access tokens, or refresh tokens in browser code, mobile bundles, public notebooks, logs, or generated client-side code.
 
 ## Installation
 
-Until the package is released on PyPI, install it from the source repository after the SDK PR is merged:
-
-```bash
-git clone https://github.com/quran/api-python.git
-cd api-python
-python -m pip install -e .
-```
-
-After the official PyPI release:
+Install the released package from PyPI:
 
 ```bash
 python -m pip install quran-foundation-api

--- a/tests/sdk-docs-config.test.cjs
+++ b/tests/sdk-docs-config.test.cjs
@@ -92,12 +92,15 @@ const getSdkCategory = (sidebarName, label) => {
 
 const getDocTitle = (docId) => {
   const docPath = path.join(docsDir, `${docId}.mdx`);
-  const content = fs.readFileSync(docPath, 'utf8');
+  const content = getDocContent(docId);
   const titleMatch = content.match(/^title:\s+"([^"]+)"/m);
 
   assert.ok(titleMatch, `expected ${docId} to have a title`);
   return titleMatch[1];
 };
+
+const getDocContent = (docId) =>
+  fs.readFileSync(path.join(docsDir, `${docId}.mdx`), 'utf8');
 
 test('surfaces the new JavaScript SDK pages in shared sidebars', () => {
   for (const sidebarName of ['APIsSidebar', 'APIsVersionedSidebar']) {
@@ -132,6 +135,31 @@ test('surfaces the Python SDK page in shared sidebars', () => {
         `expected ${sidebarName} to include ${expectedDocId}`,
       );
     }
+  }
+});
+
+test('documents the released Python SDK package install path', () => {
+  const sdkIndex = getDocContent('sdk/index');
+  const pythonIndex = getDocContent('sdk/python/index');
+
+  assert.match(
+    sdkIndex,
+    /\| \*\*Python\*\*\s+\| \[`quran-foundation-api`\]\(\/docs\/sdk\/python\)\s+\| Available \|/,
+  );
+  assert.match(pythonIndex, /https:\/\/pypi\.org\/project\/quran-foundation-api\//);
+  assert.match(pythonIndex, /python -m pip install quran-foundation-api/);
+
+  for (const staleText of [
+    'preview package',
+    'Preview SDK',
+    'Until the package is released on PyPI',
+    'after the SDK PR is merged',
+    'python -m pip install -e .',
+  ]) {
+    assert.doesNotMatch(
+      `${sdkIndex}\n${pythonIndex}`,
+      new RegExp(staleText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'),
+    );
   }
 });
 


### PR DESCRIPTION
Summary:
- Update the SDK overview to mark the Python SDK as available instead of preview.
- Replace prerelease/source install instructions with the released PyPI install command.
- Link the Python SDK page to the PyPI package page and describe it as the official package.
- Add a regression test that blocks the stale prerelease wording from coming back.

Why:
- `quran-foundation-api` is now published on PyPI as version 0.1.0, so the public docs should not tell developers to clone the SDK repo or wait for a release.

Validation:
- `NODE_PATH=C:\Code\qf-api-docs-pr167\node_modules C:\Code\node-v22.22.2-win-x64\node.exe --test tests\sdk-docs-config.test.cjs` passed: 7 tests.
- `git diff --check` passed.
- Public docs/static scan found no remaining prerelease/source-install wording.