### PR TITLE
docs: update Python SDK agent prompt install

### DIFF
--- a/static/.well-known/agent-prompts/index.json
+++ b/static/.well-known/agent-prompts/index.json
@@ -39,8 +39,8 @@
       "title": "Integrate the Quran Foundation Python SDK safely",
       "description": "Add quran-foundation-api to a trusted server-side Python app, script, job, notebook, or AI workflow while preserving token boundaries and documented endpoint usage.",
       "targetStack": "Python",
-      "status": "preview",
-      "command": "git clone https://github.com/quran/api-python.git && cd api-python && python -m pip install -e .",
+      "status": "available",
+      "command": "python -m pip install quran-foundation-api",
       "sdkEntrypoints": ["quran_foundation.QuranClient"],
       "docsUrl": "https://api-docs.quran.foundation/docs/sdk/python/",
       "promptUrl": "https://api-docs.quran.foundation/agent-prompts/qf-python-sdk-integration.md"

--- a/static/agent-prompts/qf-python-sdk-integration.md
+++ b/static/agent-prompts/qf-python-sdk-integration.md
@@ -5,15 +5,7 @@ Integrate the Quran Foundation Python SDK into a trusted server-side Python app,
 Requirements:
 
 - Use the official Python SDK package `quran-foundation-api`, imported as `quran_foundation`.
-- Until the package is released on PyPI, install from the source repository after the SDK PR is merged:
-
-```bash
-git clone https://github.com/quran/api-python.git
-cd api-python
-python -m pip install -e .
-```
-
-- After the official PyPI release, install with:
+- Install the released package from PyPI:
 
 ```bash
 python -m pip install quran-foundation-api

--- a/tests/agent-prompts.test.cjs
+++ b/tests/agent-prompts.test.cjs
@@ -42,9 +42,8 @@ test('publishes scaffold, SDK, OAuth, and review agent prompts', () => {
     (prompt) => prompt.id === 'QF_PYTHON_SDK_INTEGRATION_PROMPT_V1',
   );
   assert.ok(pythonPrompt, 'expected Python SDK integration prompt to be registered');
-  assert.equal(pythonPrompt.status, 'preview');
-  assert.match(pythonPrompt.command, /api-python/);
-  assert.match(pythonPrompt.command, /pip install -e \./);
+  assert.equal(pythonPrompt.status, 'available');
+  assert.equal(pythonPrompt.command, 'python -m pip install quran-foundation-api');
   assert.equal(pythonPrompt.promptUrl, 'https://api-docs.quran.foundation/agent-prompts/qf-python-sdk-integration.md');
 });
 
@@ -72,9 +71,13 @@ test('prompts constrain agents to official commands, docs, SDK boundaries, and c
 
   const pythonPrompt = readPrompt('qf-python-sdk-integration.md');
   assert.match(pythonPrompt, /quran-foundation-api/);
+  assert.match(pythonPrompt, /python -m pip install quran-foundation-api/);
   assert.match(pythonPrompt, /from quran_foundation import QuranClient/);
   assert.match(pythonPrompt, /Content\/Search calls use an app access token/);
   assert.match(pythonPrompt, /Run live smoke checks only with approved credentials/);
+  assert.doesNotMatch(pythonPrompt, /api-python/);
+  assert.doesNotMatch(pythonPrompt, /git clone/);
+  assert.doesNotMatch(pythonPrompt, /pip install -e \./);
 });
 
 test('labels the shared sidebar prompt hub clearly', () => {


### PR DESCRIPTION
Summary:
- Update the Python SDK agent prompt to install the released PyPI package with `python -m pip install quran-foundation-api`.
- Update the `.well-known/agent-prompts` registry command and status for the Python prompt.
- Update agent prompt tests so they require the PyPI install command and reject private `api-python` clone/editable-install guidance.

Why:
- The Python SDK package is now released on PyPI, but the agent prompt and prompt registry still directed agents to clone the private SDK repository and install editable source.

Validation:
- `NODE_PATH=C:\Code\qf-api-docs-pr167\node_modules C:\Code\node-v22.22.2-win-x64\node.exe --test tests\agent-prompts.test.cjs tests\sdk-docs-config.test.cjs` passed: 13 tests.
- `git diff --check` passed.
- Public `static` and `docs` scan found no remaining `api-python`, `git clone https://github.com/quran/api-python`, or editable-install prompt guidance.