### PR TITLE
Remove duplicate JavaScript SDK heading

### DIFF
--- a/docs/sdk/javascript/index.mdx
+++ b/docs/sdk/javascript/index.mdx
@@ -9,8 +9,6 @@ import AgentPromptCallout from "@site/src/components/AgentPromptCallout";
 
 export const staticAssetHref = (href) => href;
 
-# JavaScript SDK
-
 Purpose: Choose the correct SDK entrypoint before you write code.
 Use this when: You want to use Quran Foundation APIs from JavaScript or TypeScript.
 Do not use this when: You only need raw HTTP examples and do not want an SDK.


### PR DESCRIPTION
Removes the duplicate markdown H1 from the JavaScript SDK page. The frontmatter title already renders the page heading in Docusaurus, so the extra # JavaScript SDK line caused the heading to appear twice. 