### PR TITLE
Fix Search API token guidance

### DIFF
--- a/openAPI/search/v1.json
+++ b/openAPI/search/v1.json
@@ -294,7 +294,7 @@
   },
   "info": {
     "title": "Quran.Foundation Search API",
-    "description": "Quran.Foundation Search API provides programmatic access to search Quran content including verses, chapters, juz, pages, and translations. This is distinct from user-specific data like notes and bookmarks provided by [User-related APIs](/docs/category/user-related-apis).\n\n## How to get access\n\nWe are using OAuth2 flows to authenticate and authorize requests. To get started, you need to [get an access token](/docs/tutorials/oidc/getting-started-with-oauth2#obtaining-oauth-20-client-credentials) to make requests to our APIs. Then follow the steps mentioned [here](/docs/tutorials/oidc/getting-started-with-oauth2). The required scope is [`search`](/docs/user_related_apis_versioned/scopes#search).",
+    "description": "Quran.Foundation Search API provides programmatic access to search Quran content including verses, chapters, juz, pages, and translations. This is distinct from user-specific data like notes and bookmarks provided by [User-related APIs](/docs/category/user-related-apis).\n\n## How to get access\n\nBefore calling the Search APIs, generate an access token with the `search` scope. Use the `client_credentials` grant type when sending a request to [The OAuth 2.0 Token Endpoint](/docs/oauth2_apis_versioned/oauth-2-token-exchange), then include the returned token in the `x-auth-token` header and your client ID in the `x-client-id` header on each request.",
     "version": "1.0",
     "contact": {}
   },


### PR DESCRIPTION
﻿## Summary

- Update the Search API OpenAPI source description to tell developers to generate an access token with the `search` scope.
- Point developers to the OAuth 2.0 Token Endpoint with the `client_credentials` grant type.
- Keep `search` formatted as inline code without making it a link.

## Why

The previous Search API intro linked users to the manual OAuth2 user-login tutorial, which is the wrong flow for obtaining a Search API token.

## Notes

This PR intentionally changes only `openAPI/search/v1.json`. The generated Docusaurus MDX files are left untouched and can be regenerated by the normal docs generation flow.

## Validation

- `node --test` with the Windows-expanded `tests/**/*.test.cjs` file list: 131/131 passing
- `git diff --check HEAD^ HEAD`
- `openAPI/search/v1.json` parsed successfully
