### PR TITLE
Add error handling guidance to API quickstarts

### DIFF
--- a/docs/quickstart/first-api-call.md
+++ b/docs/quickstart/first-api-call.md
@@ -127,6 +127,20 @@ async function listChapters() {
 }
 ```
 
+## Handle Errors
+
+Check the HTTP status before trusting the response body. Content API error responses usually include a JSON body with `message`, `type`, and `success: false`; endpoint reference pages show the exact response shapes.
+
+| Status | What it usually means | What to do |
+| --- | --- | --- |
+| `400` or `422` | Missing headers, invalid query parameters, or validation failure | Fix the request before retrying. |
+| `401` | The access token is missing, expired, or invalid | Clear the cached token, request a new Client Credentials token, and retry once. |
+| `403` | Wrong client, wrong environment, or missing `content` scope/permission | Confirm `x-client-id`, token environment, and `scope=content`. Do not retry in a loop. |
+| `429` | Rate limit exceeded | Back off and retry later. Prefer exponential backoff with jitter. |
+| `500`, `502`, `503`, `504` | Temporary server or upstream failure | Retry with bounded backoff, then surface a temporary failure. |
+
+Client Credentials does not use a `refresh_token`. When a Content API token expires, re-request a new token from `/oauth2/token`. See [token management](/docs/quickstart/token-management) for the full cache and retry-once pattern.
+
 ## Backend Proxy Pattern
 
 Prefer exposing a backend route instead of letting the browser call the Content APIs directly.
@@ -163,6 +177,11 @@ Requirements
 - Call GET /content/api/v4/chapters against the correct prelive or production base URL.
 - Send both required headers: x-auth-token and x-client-id.
 - Reuse the existing backend token helper instead of requesting a new token for every request.
+- Handle non-2xx responses safely:
+  - 401: clear cached token, re-request a Client Credentials token, and retry once.
+  - 403: check client credentials, environment, and scope=content.
+  - 429 and 5xx: retry only with bounded backoff.
+  - 400/422: surface a request validation error instead of retrying blindly.
 - Expose a backend route or service method that returns the chapters response without leaking credentials to the frontend.
 - Verify success by checking that the response contains a chapters array.
 

--- a/docs/tutorials/oidc/getting-started-with-oauth2.mdx
+++ b/docs/tutorials/oidc/getting-started-with-oauth2.mdx
@@ -558,6 +558,8 @@ def get_collections(access_token: str):
 </details>
 
 
+Handle User API failures at this layer as well: refresh once and retry once on `401`, treat `403` as a scope/permission or origin problem, and use bounded backoff for `429` and temporary `5xx` errors. The [Common Issues & Troubleshooting](#common-issues-troubleshooting) table below is the detailed reference.
+
 ---
 
 ## Step 5: Refresh the Access Token (offline_access scope) {#step-5-refresh-the-access-token-offline-access-scope}

--- a/docs/tutorials/oidc/user-apis-quickstart.mdx
+++ b/docs/tutorials/oidc/user-apis-quickstart.mdx
@@ -95,6 +95,12 @@ const response = await fetch(
   }
 );
 
+if (!response.ok) {
+  const errorBody = await response.json().catch(() => null);
+  const errorType = errorBody?.type ? ` (${errorBody.type})` : "";
+  throw new Error(`User API request failed: ${response.status}${errorType}`);
+}
+
 const bookmarks = await response.json();
 ```
 
@@ -102,6 +108,20 @@ For web apps, SDK or raw HTTP requests are usually made by your backend or
 serverless proxy, not by page JavaScript. Cookies are for your app's own
 session; `x-auth-token` and `x-client-id` are the headers your server sends to
 Quran Foundation.
+
+## Handle API Errors
+
+Always check the response status before using the JSON payload. User API errors generally return a JSON body with `message`, `type`, and `success: false`; endpoint reference pages show the exact shape for each operation.
+
+| Status | What it usually means | What to do |
+| --- | --- | --- |
+| `400` or `422` | Invalid request, missing required parameters, or validation failure | Fix the request or form data before retrying. |
+| `401` | Missing, expired, or invalid user `access_token` | If you have a `refresh_token`, refresh once and retry once. If it still fails, require the user to sign in again. |
+| `403` | Missing scope/permission, wrong environment, or a browser/origin restriction | Route web calls through your backend, confirm the token environment, and request the correct scopes. |
+| `429` | Rate limit exceeded | Back off and retry later. Prefer exponential backoff with jitter. |
+| `500`, `502`, `503`, `504` | Temporary server or upstream failure | Retry with bounded backoff, then surface a temporary failure. |
+
+Do not log `access_token`, `refresh_token`, `id_token`, authorization codes, `code_verifier`, or `QF_CLIENT_SECRET` while handling failures. For detailed OAuth2 and User API troubleshooting, see [Common Issues & Troubleshooting](/docs/tutorials/oidc/getting-started-with-oauth2#common-issues-troubleshooting).
 
 ## Platform Guides
 


### PR DESCRIPTION
## Summary
- Add error-handling guidance to the Content API first-call quickstart.
- Add response status handling and an error table to the User APIs quickstart.
- Point the OAuth2 tutorial back to the detailed troubleshooting guidance for User API failures.

## Validation
- `git diff --check`