### PR TITLE
Document OAuth token revocation and refine developer terms

### DIFF
--- a/openAPI/oauth2-apis/v1.json
+++ b/openAPI/oauth2-apis/v1.json
@@ -483,7 +483,7 @@
     "/oauth2/revoke": {
       "post": {
         "summary": "Revoke OAuth 2.0 Access or Refresh Token",
-        "description": "Revokes an OAuth 2.0 access or refresh token so it can no longer be used. Revoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by the client it was generated for.\n\nConfidential clients should authenticate with HTTP Basic authentication. Client credentials may also be sent in the form body.",
+        "description": "Revokes an OAuth 2.0 access or refresh token so it can no longer be used. Revoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by the client it was generated for.\n\nAuthenticate confidential clients with HTTP Basic authentication. Clients configured for form-body authentication may instead include both `client_id` and `client_secret` in the request body.",
         "operationId": "revokeOAuth2Token",
         "requestBody": {
           "required": true,
@@ -508,6 +508,24 @@
                 },
                 "required": ["token"],
                 "type": "object"
+              },
+              "examples": {
+                "httpBasic": {
+                  "summary": "Revoke a token using HTTP Basic authentication",
+                  "description": "Send the client ID and client secret in the HTTP Basic Authorization header.",
+                  "value": {
+                    "token": "qf_access_or_refresh_token_example"
+                  }
+                },
+                "formBody": {
+                  "summary": "Revoke a token using form-body authentication",
+                  "description": "Use this method only when the OAuth client is configured for form-body authentication.",
+                  "value": {
+                    "client_id": "quran-demo",
+                    "client_secret": "qf_client_secret_example",
+                    "token": "qf_access_or_refresh_token_example"
+                  }
+                }
               }
             }
           }
@@ -553,7 +571,7 @@
             }
           }
         },
-        "security": [{ "basicAuth": [] }, {}],
+        "security": [{ "basicAuth": [] }],
         "tags": ["OAuth2"]
       }
     },

--- a/openAPI/oauth2-apis/v1.json
+++ b/openAPI/oauth2-apis/v1.json
@@ -553,7 +553,7 @@
             }
           }
         },
-        "security": [{ "basicAuth": [] }],
+        "security": [{ "basicAuth": [] }, {}],
         "tags": ["OAuth2"]
       }
     },

--- a/openAPI/oauth2-apis/v1.json
+++ b/openAPI/oauth2-apis/v1.json
@@ -480,6 +480,83 @@
         "tags": ["OAuth2"]
       }
     },
+    "/oauth2/revoke": {
+      "post": {
+        "summary": "Revoke OAuth 2.0 Access or Refresh Token",
+        "description": "Revokes an OAuth 2.0 access or refresh token so it can no longer be used. Revoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by the client it was generated for.\n\nConfidential clients should authenticate with HTTP Basic authentication. Client credentials may also be sent in the form body.",
+        "operationId": "revokeOAuth2Token",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "properties": {
+                  "client_id": {
+                    "description": "The client identifier. Include this when client credentials are not sent using HTTP Basic authentication.",
+                    "type": "string",
+                    "example": "quran-demo"
+                  },
+                  "client_secret": {
+                    "description": "The client secret. Include this for confidential clients when credentials are not sent using HTTP Basic authentication.",
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "The OAuth 2.0 access token or refresh token to revoke.",
+                    "type": "string",
+                    "example": "qf_access_or_refresh_token_example"
+                  }
+                },
+                "required": ["token"],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token revoked successfully. The response body is empty."
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/errorOAuth2" },
+                "examples": {
+                  "invalid_request": {
+                    "summary": "Token parameter is missing or malformed",
+                    "value": {
+                      "error": "invalid_request",
+                      "error_description": "The token parameter is required.",
+                      "status_code": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid client credentials",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/errorOAuth2" },
+                "examples": {
+                  "invalid_client": {
+                    "summary": "Client authentication failed",
+                    "value": {
+                      "error": "invalid_client",
+                      "error_description": "Client authentication failed.",
+                      "status_code": 401
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "basicAuth": [] }],
+        "tags": ["OAuth2"]
+      }
+    },
     "/oauth2/auth": {
       "get": {
         "summary": "OAuth 2.0 Authorize Endpoint",

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -6,9 +6,9 @@ sidebar_label: Developer Terms of Service
 
 # Quran Foundation Developer Terms of Service (“Terms”)
 
-**Last updated:** 2025-06-13
+**Last updated:** 2026-07-30
 
-PLEASE READ CAREFULLY. By accessing or using the Quran Foundation (“QF”) application-programming interfaces, software development kits, webhooks, OAuth services, related documentation, and any associated services (collectively, **“APIs”**), you (“**Developer**,” “**you**”) agree to be bound by these Terms, the QF Developer Privacy-Policy Requirements, and all other guidelines published at the [Developer Privacy Policy Packet](/legal/developer-privacy/). (together, the **“Developer Policies”**).
+PLEASE READ CAREFULLY. By accessing or using the Quran Foundation (“QF”) application programming interfaces, software development kits, webhooks, OAuth services, related documentation, and any associated services (collectively, **“APIs”**), you (“**Developer**,” “**you**”) agree to be bound by these Terms, the QF Developer Privacy Policy Requirements, and all other guidelines published in the [Developer Privacy Policy Packet](/legal/developer-privacy/) (together, the **“Developer Policies”**).
 
 If you use the APIs on behalf of an organization, you represent that you have authority to bind that organization to these Terms, and “Developer” will refer to that organization.
 
@@ -53,7 +53,7 @@ Except for the licenses expressly granted, QF retains all right, title, and inte
 Developer must **NOT**:
 
 1. Attempt to extract, scrape, or index QF Content or User Data outside the API responses.  
-2. Exceed published rate limits or quotas nor attempt to circumvent technical restrictions.  
+2. Exceed published rate limits or quotas or attempt to circumvent technical restrictions.
 3. Cache or store QF Content longer than **1 week** unless expressly permitted.  
 4. Use QF Content or User Data to build advertising profiles, biometric identifiers, or machine-learning models without written consent.  
 5. Display or transmit content that is disparaging to Islam, promotes extremist ideology, or misrepresents the Qurʾān.  
@@ -65,7 +65,7 @@ Developer must **NOT**:
 Developer must:
 
 - Implement industry-standard security (e.g., **TLS 1.2+**, encryption at rest, least-privilege access, secret rotation).  
-- Process User Data only for the feature(s) disclosed to and authorised by the user, in line with the **Developer Privacy-Policy Requirements**.  
+- Process User Data only for the feature(s) disclosed to and authorised by the user, in line with the **Developer Privacy Policy Requirements**.
 - Provide a publicly reachable **Privacy Policy** and **Terms of Use** for the Application. This Privacy Policy must, at a minimum, incorporate all principles and requirements set forth in the [QF Developer Privacy Policy Requirements](/legal/developer-privacy/).
 - Promptly (within **24 hours**) report to **developers@quran.com** any actual or suspected unauthorised access, security breach, or data exposure related to the APIs.
 
@@ -79,7 +79,7 @@ Developer must:
 ### 3.4 Audit & monitoring
 
 - QF may **monitor API activity** to verify compliance. Developer shall **not interfere** with such monitoring.
-- Upon written notice, Developer will **provide logs, architecture diagrams, and other information** reasonably required for QF to audit compliance,
+- Upon written notice, Developer will **provide logs, architecture diagrams, and other information** reasonably required for QF to audit compliance.
 
 ---
 
@@ -94,7 +94,7 @@ QF may modify or discontinue any API, feature, or endpoint. QF will provide comm
 QF may suspend or revoke Developer’s API credentials, **immediately and without liability**, if:
 
 - Developer breaches these Terms or the Developer Policies; or  
-- QF reasonably believes suspension is necessary to protect its systems, Users, or the integrity of the Qurʾān; or  
+- QF reasonably believes suspension is necessary to protect its systems, users, or the integrity of the Qurʾān; or
 - Required by law.
 
 ---
@@ -163,7 +163,7 @@ Failure to enforce any provision is not a waiver.
 Developer may not assign these Terms without QF’s prior written consent. QF may assign these Terms without restriction.
 
 **Notices.**  
-Notices must be in writing and are deemed given when sent to the email associated with Developer’s account or to **developers@quran.com**.
+Notices must be in writing and are deemed given when sent to **developers@quran.com**.
 
 ---
 

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -66,8 +66,8 @@ Developer must:
 
 - Implement industry-standard security (e.g., **TLS 1.2+**, encryption at rest, least-privilege access, secret rotation).  
 - Process User Data only for the feature(s) disclosed to and authorised by the user, in line with the **Developer Privacy-Policy Requirements**.  
-- Provide a publicly reachable **Privacy Policy** and **Terms of Use** for the Application. This Privacy Policy must, at a minimum, incorporate all principles and requirements set forth in the QF Developer Privacy Policy Requirements, available at \[insert link to guidelines].  
-- Promptly (within **24 hours**) report to **security@quran.com** any actual or suspected unauthorised access, security breach, or data exposure related to the APIs.
+- Provide a publicly reachable **Privacy Policy** and **Terms of Use** for the Application. This Privacy Policy must, at a minimum, incorporate all principles and requirements set forth in the [QF Developer Privacy Policy Requirements](/legal/developer-privacy/).
+- Promptly (within **24 hours**) report to **developers@quran.com** any actual or suspected unauthorised access, security breach, or data exposure related to the APIs.
 
 ### 3.3 OAuth and scopes
 
@@ -163,7 +163,7 @@ Failure to enforce any provision is not a waiver.
 Developer may not assign these Terms without QF’s prior written consent. QF may assign these Terms without restriction.
 
 **Notices.**  
-Notices must be in writing and are deemed given when sent to the email associated with Developer’s account or to **legal@quran.foundation**.
+Notices must be in writing and are deemed given when sent to the email associated with Developer’s account or to **developers@quran.com**.
 
 ---
 

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -163,7 +163,7 @@ Failure to enforce any provision is not a waiver.
 Developer may not assign these Terms without QF’s prior written consent. QF may assign these Terms without restriction.
 
 **Notices.**  
-Notices must be in writing and are deemed given when sent to **developers@quran.com**.
+Notices to QF must be in writing and are deemed given when sent to **developers@quran.com**. Notices to Developer must be in writing and are deemed given when sent to the email associated with Developer’s account.
 
 ---
 

--- a/tests/oauth-revocation-and-developer-terms.test.cjs
+++ b/tests/oauth-revocation-and-developer-terms.test.cjs
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repositoryRoot = path.join(__dirname, '..');
+const oauthSpec = JSON.parse(
+  fs.readFileSync(
+    path.join(repositoryRoot, 'openAPI', 'oauth2-apis', 'v1.json'),
+    'utf8',
+  ),
+);
+const developerTerms = fs.readFileSync(
+  path.join(repositoryRoot, 'src', 'pages', 'legal', 'developer-terms.mdx'),
+  'utf8',
+);
+
+test('does not advertise anonymous access to the token revocation endpoint', () => {
+  const revocationOperation = oauthSpec.paths['/oauth2/revoke'].post;
+
+  assert.deepEqual(revocationOperation.security, [{ basicAuth: [] }]);
+});
+
+test('defines notice delivery separately for QF and the external Developer', () => {
+  assert.match(
+    developerTerms,
+    /Notices to QF .*sent to \*\*developers@quran\.com\*\*\./,
+  );
+  assert.match(
+    developerTerms,
+    /Notices to Developer .*email associated with Developer’s account\./,
+  );
+});


### PR DESCRIPTION
## Summary

- document the OAuth 2.0 token revocation endpoint, `POST /oauth2/revoke`
- describe its form-encoded parameters, authentication methods, examples, and responses
- model HTTP Basic authentication without an anonymous OpenAPI fallback while documenting form-body client authentication
- replace the developer terms contact addresses with `developers@quran.com`
- link the Developer Privacy Policy Packet and clean up related wording, punctuation, and consistency issues
- define notice delivery separately for QF and the external Developer
- add regression coverage for revocation security and the notices clause

## Why

The revocation endpoint was available but missing from the generated API documentation. The developer terms also contained outdated contact addresses, an unfilled guidelines-link reference, an ambiguous notices clause, and several editorial defects.

OpenAPI 3.0 cannot represent form-body client credentials as a security scheme. The operation therefore models HTTP Basic authentication conservatively, documents form-body authentication as an alternative, and avoids declaring anonymous access.

## Validation

- all 133 repository tests pass
- focused regression tests cover revocation security and bilateral notice delivery
- the OAuth OpenAPI document parses successfully
- `git diff --check` passes
