### PR TITLE
Complete JavaScript SDK audio documentation

### DIFF
--- a/docs/sdk/javascript/audio.mdx
+++ b/docs/sdk/javascript/audio.mdx
@@ -15,7 +15,9 @@ Allowed runtimes: Node.js, serverless functions, workers.
 Required credentials: `client_id`, `client_secret`, Content API access.  
 Minimal import: `@quranjs/api/server`.
 
-Use `@quranjs/api/server`.
+## Create a Server Client
+
+Use `@quranjs/api/server`. Content API credentials must stay on your backend.
 
 ```ts
 import { createServerClient } from "@quranjs/api/server";
@@ -24,9 +26,6 @@ const client = createServerClient({
   clientId: process.env.QF_CLIENT_ID!,
   clientSecret: process.env.QF_CLIENT_SECRET!,
 });
-
-const chapterAudio = await client.content.v4.audio.chapterRecitation.list("7");
-const verseAudio = await client.content.v4.audio.verseRecitation.byKey("1:1", "7");
 ```
 
 ## Choose the Right Audio Source
@@ -37,8 +36,109 @@ const verseAudio = await client.content.v4.audio.verseRecitation.byKey("1:1", "7
 | Chapter playback | `client.content.v4.audio.chapterRecitation` | Full chapter recitation URL | Use this for continuous chapter playback. |
 | Ayah playback with timing | `client.content.v4.audio.verseRecitation` | Verse recitation URL plus optional timing metadata | Use this for ayah recitations and highlighting. This is distinct from `word.audioUrl`. |
 
-## Common Mistake
+## Find the Correct Audio Resource ID
+
+Chapter audio and ayah-by-ayah audio use different resource catalogs.
+
+```ts
+const chapterReciters =
+  await client.content.v4.resources.chapterReciters.list();
+
+const ayahRecitations =
+  await client.content.v4.resources.recitations.list();
+```
+
+- Use an ID from `chapterReciters` with `chapterRecitation`, the chapter [timestamp endpoint](/docs/content_apis_versioned/audio-reciter-timestamp), and the chapter [timestamp lookup endpoint](/docs/content_apis_versioned/audio-reciter-lookup).
+- Use an ID from `ayahRecitations` with `verseRecitation`.
+
+:::warning Use the correct ID family
+
+A chapter `reciterId` from the [Chapter Reciters endpoint](/docs/content_apis_versioned/chapter-reciters) is not interchangeable with an ayah-by-ayah `recitationId` from the [Recitations endpoint](/docs/content_apis_versioned/recitations).
+
+:::
+
+## Chapter Recitation Helpers
+
+Use chapter recitations when you want one continuous audio file for a Surah.
+
+```ts
+const reciterId = "7";
+
+// Return every available chapter audio file for this reciter.
+const allChapterAudio =
+  await client.content.v4.audio.chapterRecitation.list(reciterId);
+
+// Return the chapter 1 audio file for this reciter.
+const oneChapterAudio =
+  await client.content.v4.audio.chapterRecitation.get(reciterId, "1");
+```
+
+`chapterRecitation.list()` returns an array. `chapterRecitation.get()` returns one chapter audio item. Each item includes:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Audio file ID. |
+| `chapterId` | Chapter number for the file. |
+| `fileSize` | File size in bytes. |
+| `format` | Audio format, such as `mp3`. |
+| `audioUrl` | Absolute URL of the chapter audio file. |
+
+Read the endpoint-level schemas for [all chapter files](/docs/content_apis_versioned/chapter-reciter-audio-files) and [one chapter file](/docs/content_apis_versioned/chapter-reciter-audio-file).
+
+## Ayah Recitation Helpers
+
+Use ayah recitations when you need one audio file per verse.
+
+```ts
+const recitationId = "7";
+
+// Return every ayah audio file in chapter 1.
+const chapterAyahAudio =
+  await client.content.v4.audio.verseRecitation.byChapter("1", recitationId);
+
+// Return the audio file for ayah 2:255.
+const oneAyahAudio =
+  await client.content.v4.audio.verseRecitation.byKey("2:255", recitationId);
+```
+
+Both helpers return an object with `audioFiles` and `pagination`. Every item in `audioFiles` includes:
+
+| Field | Meaning |
+| --- | --- |
+| `verseKey` | Verse key in `chapter:verse` format. |
+| `url` | Original relative or absolute URL returned by the Content API. |
+| `audioUrl` | Absolute playback URL normalized by the SDK. |
+| `id`, `chapterId`, `segments`, `format` | Optional fields when requested and available. |
+
+Request optional ayah fields with the `fields` option:
+
+```ts
+const ayahAudioWithSegments =
+  await client.content.v4.audio.verseRecitation.byKey("2:255", recitationId, {
+    fields: { id: true, chapterId: true, segments: true, format: true },
+  });
+```
+
+## Advanced Audio Operations
+
+The Content API also supports ayah-audio filtering by Juz, page, Hizb, Rub el Hizb, Manzil, and Ruku, plus chapter timestamp and timestamp-lookup operations. These operations do not currently have dedicated typed helpers on `client.content.v4.audio`.
+
+Use the generated [Content API Audio reference](/docs/category/content-apis-4.0.0) for their parameters and response schemas. Useful starting points include:
+
+- [All audio files for one ayah recitation](/docs/content_apis_versioned/recitation-audio-files)
+- [Ayah recitations for a Juz](/docs/content_apis_versioned/list-juz-recitation)
+- [Ayah recitations for a page](/docs/content_apis_versioned/list-page-recitation)
+- [Chapter or verse timestamp range](/docs/content_apis_versioned/audio-reciter-timestamp)
+- [Look up a verse by playback timestamp](/docs/content_apis_versioned/audio-reciter-lookup)
+
+## Usage Permissions
+
+Audio returned by the APIs is QF Content. Review the [Quran Foundation Developer Terms](/legal/developer-terms) before implementing storage, offline playback, redistribution, or commercial use. The Developer Terms are the authoritative source for permitted use.
+
+## Common Mistakes
 
 Do not assume audio is browser-safe just because the final result is a media URL. The API request still uses server credentials.
 
 Also do not append `word.audioUrl` to `/content/api/v4`. Word-by-word audio files are public CDN assets, not authenticated Content API endpoints.
+
+Do not pass a chapter `reciterId` to an ayah `verseRecitation` helper, or an ayah `recitationId` to a chapter `chapterRecitation` helper.

--- a/docs/superpowers/plans/2026-08-04-sdk-audio-docs.md
+++ b/docs/superpowers/plans/2026-08-04-sdk-audio-docs.md
@@ -1,0 +1,115 @@
+# Complete JavaScript SDK Audio Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the JavaScript SDK Audio API page into a complete entry point for chapter, ayah, and word-level playback.
+
+**Architecture:** Keep the hand-written SDK guide focused on typed `@quranjs/api/server` helpers and route developers to the generated Content API reference for advanced raw endpoint capabilities. Derive every method name, parameter order, response field, and ID source from the current `api-js` implementation and public OpenAPI contract.
+
+**Tech Stack:** Docusaurus 2, MDX, TypeScript examples, Yarn 1, Node.js.
+
+## Global Constraints
+
+- Do not change SDK functionality or generated API reference files.
+- Do not document generated `Promise<unknown>` raw operations as stable typed SDK helpers.
+- Do not duplicate complete endpoint schemas maintained by the generated Content API reference.
+- Do not invent licensing or attribution policy beyond the published Developer Terms.
+- Keep all Content API credential handling on the server.
+
+---
+
+### Task 1: Complete the JavaScript Audio API guide
+
+**Files:**
+- Modify: `docs/sdk/javascript/audio.mdx`
+- Reference: `C:/Code/api-js/packages/api/src/sdk/audio.ts`
+- Reference: `C:/Code/api-js/packages/api/src/runtime/create-client.ts`
+- Reference: `openAPI/content/v4.json`
+
+**Interfaces:**
+- Consumes: `client.content.v4.audio.chapterRecitation.list(reciterId, query?)`, `client.content.v4.audio.chapterRecitation.get(reciterId, chapterId, query?)`, `client.content.v4.audio.verseRecitation.byChapter(chapterId, recitationId, query?)`, and `client.content.v4.audio.verseRecitation.byKey(verseKey, recitationId, query?)`.
+- Produces: One stable documentation URL at `/docs/sdk/javascript/audio` that explains typed audio retrieval, ID discovery, response interpretation, advanced endpoint links, backend safety, and usage terms.
+
+- [ ] **Step 1: Verify the SDK contract before editing**
+
+Run:
+
+```powershell
+rg -n "chapterRecitation|verseRecitation|findAllChapterRecitations|findChapterRecitationById|findVerseRecitationsByChapter|findVerseRecitationsByKey" C:\Code\api-js\packages\api\src\sdk\audio.ts C:\Code\api-js\packages\api\src\runtime\create-client.ts
+```
+
+Expected: all four typed helpers and their parameter order are present.
+
+- [ ] **Step 2: Expand the guide with the complete typed workflow**
+
+Update `docs/sdk/javascript/audio.mdx` to include:
+
+```ts
+const chapterReciters =
+  await client.content.v4.resources.chapterReciters.list();
+const ayahRecitations =
+  await client.content.v4.resources.recitations.list();
+
+const allChapterAudio =
+  await client.content.v4.audio.chapterRecitation.list("7");
+const oneChapterAudio =
+  await client.content.v4.audio.chapterRecitation.get("7", "1");
+
+const chapterAyahAudio =
+  await client.content.v4.audio.verseRecitation.byChapter("1", "7");
+const oneAyahAudio =
+  await client.content.v4.audio.verseRecitation.byKey("2:255", "7");
+```
+
+Add prose that explicitly states:
+
+- `chapterReciters.list()` returns IDs for chapter audio and timing endpoints.
+- `recitations.list()` returns IDs for ayah-by-ayah audio.
+- The two ID families are not interchangeable.
+- Chapter responses expose `audioUrl`, `chapterId`, `fileSize`, and `format`.
+- Ayah responses expose `audioFiles`, `pagination`, `verseKey`, `url`, and normalized absolute `audioUrl`.
+- Word pronunciation uses `word.audioUrl` from the Verses API.
+
+- [ ] **Step 3: Add advanced endpoint and policy links**
+
+Link the guide to:
+
+- `/docs/content_apis_versioned/chapter-reciters`
+- `/docs/content_apis_versioned/recitations`
+- `/docs/content_apis_versioned/chapter-reciter-audio-files`
+- `/docs/content_apis_versioned/recitation-audio-files`
+- `/docs/content_apis_versioned/audio-reciter-timestamp`
+- `/docs/content_apis_versioned/audio-reciter-lookup`
+- `/legal/developer-terms`
+
+Explain that juz, page, hizb, rub el hizb, manzil, ruku, timestamp, and lookup capabilities are documented in the raw Content API reference but do not currently have dedicated typed audio-facade helpers.
+
+- [ ] **Step 4: Run focused documentation checks**
+
+Run:
+
+```powershell
+yarn test
+yarn build
+```
+
+Expected: both commands exit with status 0; Docusaurus reports a successful production build.
+
+- [ ] **Step 5: Inspect the final diff and links**
+
+Run:
+
+```powershell
+git diff --check
+git diff -- docs/sdk/javascript/audio.mdx
+rg -n "chapterRecitation|verseRecitation|chapterReciters|Developer Terms|timestamp|lookup" docs/sdk/javascript/audio.mdx
+```
+
+Expected: no whitespace errors; all four typed helpers, both resource-ID sources, advanced capability links, and the terms link are present.
+
+- [ ] **Step 6: Commit the implementation**
+
+```powershell
+git add -- docs/sdk/javascript/audio.mdx docs/superpowers/plans/2026-08-04-sdk-audio-docs.md
+git commit -m "Complete JavaScript SDK audio documentation"
+```

--- a/docs/superpowers/specs/2026-08-04-sdk-audio-docs-design.md
+++ b/docs/superpowers/specs/2026-08-04-sdk-audio-docs-design.md
@@ -1,0 +1,59 @@
+# Complete JavaScript SDK Audio Documentation Design
+
+## Context
+
+The JavaScript SDK already exposes typed helpers for chapter and ayah recitation audio, but the current Audio API page demonstrates only two of the four helpers. It also does not explain how to discover the two different resource IDs used by chapter and ayah audio, which can lead developers to interchange `reciter_id` and `recitation_id` incorrectly.
+
+## Goal
+
+Make the JavaScript Audio API page a complete, dependable starting point for developers who want to add Quran audio playback to an application.
+
+## Scope
+
+The page will:
+
+- explain the difference between chapter recitations, ayah recitations, and word-by-word pronunciation;
+- show how to discover chapter-reciter IDs and ayah-recitation IDs;
+- document all four typed audio helpers:
+  - `chapterRecitation.list()`;
+  - `chapterRecitation.get()`;
+  - `verseRecitation.byChapter()`;
+  - `verseRecitation.byKey()`;
+- describe the principal response fields and the SDK's absolute ayah-audio URL normalization;
+- explain that Content API calls require the server SDK and that credentials must remain on the backend;
+- link to the complete raw Content API audio reference for filters and timing operations that do not have typed facade helpers;
+- link to the Developer Terms for usage, storage, redistribution, and commercial-use requirements.
+
+## Non-goals
+
+- Do not add or change SDK functionality.
+- Do not present the generated `Promise<unknown>` raw operation catalog as a stable, typed SDK surface.
+- Do not duplicate every endpoint-level parameter and response schema already maintained in the generated Content API reference.
+- Do not introduce new licensing or attribution policy beyond the published Developer Terms.
+
+## Page Structure
+
+1. Existing runtime and credential summary.
+2. Audio-source selection table.
+3. Resource-ID discovery and an explicit warning that the IDs are not interchangeable.
+4. Complete typed-helper reference with concise TypeScript examples.
+5. Response-shape notes for chapter and ayah audio.
+6. Links to advanced raw API capabilities, including alternative range filters and timestamp lookup.
+7. Server-side integration guidance.
+8. Usage-permissions link and concise, non-legal interpretation.
+9. Common mistakes.
+
+## Accuracy Boundaries
+
+Examples will use the current `@quranjs/api/server` entrypoint and the method names implemented by `api-js`. Links will point to versioned or redirect-stable pages in the Quran Foundation documentation portal. Licensing language will direct developers to the Developer Terms instead of attempting to create a parallel policy.
+
+## Validation
+
+- Run the repository test suite.
+- Run the Docusaurus production build to catch broken MDX, imports, and links that are validated locally.
+- Review the rendered content structure in the generated output when practical.
+- Confirm the Git diff contains only the design specification and the intended SDK documentation changes.
+
+## Success Criteria
+
+A developer can use one SDK page to choose the correct audio resource, obtain the correct ID, call any typed audio helper, understand the backend requirement, find advanced endpoint documentation, and locate the applicable usage terms.


### PR DESCRIPTION
## Summary

- document all four typed JavaScript SDK audio helpers
- explain how to discover the correct chapter-reciter and ayah-recitation IDs
- document response fields, optional timing fields, and normalized playback URLs
- link advanced Content API audio operations and the Developer Terms

## Why

The SDK already supports chapter and ayah recitation audio, but the existing Audio page only showed two calls and did not explain resource IDs, response shapes, advanced operations, or usage permissions.

## Validation

- `node --test <all tests/**/*.test.cjs>` — 133 passed, 0 failed
- Docusaurus production build under Node.js 22 — passed
- all 12 documentation links added to the page resolve in the production build
- independently cross-checked against the local `api-js` facade, audio implementation, types, and generated operation catalog
- independent diff review — no actionable findings

## Environment note

The repository's combined `yarn build` command still hits a pre-existing intermittent Windows file-access error while rewriting generated User API docs. Running the production Docusaurus compilation directly succeeds, including the edited Audio page.