### PR TITLE
Correct Arabic tafsir example resource id in Content API v4

### DIFF
--- a/openAPI/content/v4.json
+++ b/openAPI/content/v4.json
@@ -11354,10 +11354,10 @@
                     "value": {
                       "tafsirs": [
                         {
-                          "id": 16,
+                          "id": 15,
                           "name": "Tafsir al-Tabari",
-                          "author_name": "Imam al-Tabari",
-                          "slug": "tafsir-tabari",
+                          "author_name": "Tabari",
+                          "slug": "ar-tafsir-al-tabari",
                           "language_name": "arabic",
                           "translated_name": {
                             "name": "Tafsir al-Tabari",


### PR DESCRIPTION
## Summary

The `arabic_tafsir_resources` example under `/resources/tafsirs` in `openAPI/content/v4.json` documented Tafsir al-Tabari as resource **id 16**. In the live catalogue al-Tabari is **id 15** (`ar-tafsir-al-tabari`); id 16 is Tafsir Muyassar (`ar-tafsir-muyassar`).

This corrects three fields so the example matches the actual API response:

| Field | Before | After |
| --- | --- | --- |
| `id` | `16` | `15` |
| `author_name` | `Imam al-Tabari` | `Tabari` |
| `slug` | `tafsir-tabari` (non-existent) | `ar-tafsir-al-tabari` |

## Motivation

Reported by an API consumer who paused a tafsir integration because the documented id and the catalogue disagreed. A developer copying this example would request the wrong tafsir and get Muyassar content back with no obvious error.

## Notes for the reviewer

- Scope is deliberately narrow: only the `arabic_tafsir_resources` example block. Other `Tafsir al-Tabari` occurrences in the file are free-text `references` strings in unrelated Q&A examples and were left untouched.
- JSON validity verified with `JSON.parse`.
- The corrected id/slug values come from the reported catalogue state and were **not** independently verified against a live `/resources/tafsirs` call — that needs Content API credentials. Worth a quick confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)