### PR TITLE
Clarify weekly Content Sync requirement

### DIFF
--- a/docs/tutorials/content-sync/getting-started.mdx
+++ b/docs/tutorials/content-sync/getting-started.mdx
@@ -32,7 +32,7 @@ Instead of downloading every translation, tafsir, recitation, or article again, 
 When `next_page_url` or `snapshot_url` is present and non-null, we return a relative `/api/v4/...` path, such as `/api/v4/resources/sync?cursor=...` or `/api/v4/resources/snapshots/translations/19`. You should prefix that path with `https://apis.quran.foundation/content`.
 :::
 
-## Supported Content
+## Content Available for Offline Sync
 
 Content Sync currently supports these resource groups: `translations`, `tafsirs`, `recitations`, and `articles`.
 

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -54,7 +54,7 @@ Developer must **NOT**:
 
 1. Attempt to extract, scrape, or index QF Content or User Data outside the API responses.  
 2. Exceed published rate limits or quotas or attempt to circumvent technical restrictions.
-3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs described in the [Offline Content Cache Patterns tutorial](/docs/tutorials/content-sync/offline-cache-patterns). If you rely on exception (b), you must check for deltas at least every **7 days** and apply all available deltas.
+3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs listed in the [Supported Content section](/docs/tutorials/content-sync/getting-started#supported-content). If you rely on exception (b), you must check for deltas at least every **7 days** and apply all available deltas.
 4. Use QF Content or User Data to build advertising profiles, biometric identifiers, or machine-learning models without written consent.  
 5. Display or transmit content that is disparaging to Islam, promotes extremist ideology, or misrepresents the Qurʾān.  
 6. Subvert or disable any security, authentication, or access-control mechanism.  

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -54,7 +54,7 @@ Developer must **NOT**:
 
 1. Attempt to extract, scrape, or index QF Content or User Data outside the API responses.  
 2. Exceed published rate limits or quotas or attempt to circumvent technical restrictions.
-3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs listed in the [Supported Content section](/docs/tutorials/content-sync/getting-started#supported-content). If you rely on exception (b), you must check for deltas at least every **7 days** and apply all available deltas.
+3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs listed under [Content Available for Offline Sync](/docs/tutorials/content-sync/getting-started#content-available-for-offline-sync). If you rely on exception (b), you must check for deltas at least every **7 days** and apply all available deltas.
 4. Use QF Content or User Data to build advertising profiles, biometric identifiers, or machine-learning models without written consent.  
 5. Display or transmit content that is disparaging to Islam, promotes extremist ideology, or misrepresents the Qurʾān.  
 6. Subvert or disable any security, authentication, or access-control mechanism.  

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -54,7 +54,7 @@ Developer must **NOT**:
 
 1. Attempt to extract, scrape, or index QF Content or User Data outside the API responses.  
 2. Exceed published rate limits or quotas or attempt to circumvent technical restrictions.
-3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs listed under [Content Available for Offline Sync](/docs/tutorials/content-sync/getting-started#content-available-for-offline-sync). If you rely on exception (b), you must check for deltas at least every **7 days** and apply all available deltas.
+3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs listed under [Content Available for Offline Sync](/docs/tutorials/content-sync/getting-started#content-available-for-offline-sync). If you rely on exception (b), you must [perform a next sync](/docs/tutorials/content-sync/getting-started#next-sync) at least every **7 days** and apply all available changes.
 4. Use QF Content or User Data to build advertising profiles, biometric identifiers, or machine-learning models without written consent.  
 5. Display or transmit content that is disparaging to Islam, promotes extremist ideology, or misrepresents the Qurʾān.  
 6. Subvert or disable any security, authentication, or access-control mechanism.  

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -6,7 +6,7 @@ sidebar_label: Developer Terms of Service
 
 # Quran Foundation Developer Terms of Service (“Terms”)
 
-**Last updated:** 2026-07-30
+**Last updated:** 2026-08-10
 
 PLEASE READ CAREFULLY. By accessing or using the Quran Foundation (“QF”) application programming interfaces, software development kits, webhooks, OAuth services, related documentation, and any associated services (collectively, **“APIs”**), you (“**Developer**,” “**you**”) agree to be bound by these Terms, the QF Developer Privacy Policy Requirements, and all other guidelines published in the [Developer Privacy Policy Packet](/legal/developer-privacy/) (together, the **“Developer Policies”**).
 
@@ -54,7 +54,7 @@ Developer must **NOT**:
 
 1. Attempt to extract, scrape, or index QF Content or User Data outside the API responses.  
 2. Exceed published rate limits or quotas or attempt to circumvent technical restrictions.
-3. Cache or store QF Content longer than **1 week** unless expressly permitted.  
+3. Cache or store QF Content longer than **1 week** unless expressly permitted or the QF Content is available through the Content Sync APIs described in the [Offline Content Cache Patterns tutorial](/docs/tutorials/content-sync/offline-cache-patterns). As a strict condition of this exception, you must check for deltas at least every **7 days** and apply all available deltas.
 4. Use QF Content or User Data to build advertising profiles, biometric identifiers, or machine-learning models without written consent.  
 5. Display or transmit content that is disparaging to Islam, promotes extremist ideology, or misrepresents the Qurʾān.  
 6. Subvert or disable any security, authentication, or access-control mechanism.  

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -54,7 +54,7 @@ Developer must **NOT**:
 
 1. Attempt to extract, scrape, or index QF Content or User Data outside the API responses.  
 2. Exceed published rate limits or quotas or attempt to circumvent technical restrictions.
-3. Cache or store QF Content longer than **1 week** unless expressly permitted or the QF Content is available through the Content Sync APIs described in the [Offline Content Cache Patterns tutorial](/docs/tutorials/content-sync/offline-cache-patterns). As a strict condition of this exception, you must check for deltas at least every **7 days** and apply all available deltas.
+3. Cache or store QF Content longer than **1 week**, except where (a) QF has expressly permitted longer storage, or (b) the QF Content is available through the Content Sync APIs described in the [Offline Content Cache Patterns tutorial](/docs/tutorials/content-sync/offline-cache-patterns). If you rely on exception (b), you must check for deltas at least every **7 days** and apply all available deltas.
 4. Use QF Content or User Data to build advertising profiles, biometric identifiers, or machine-learning models without written consent.  
 5. Display or transmit content that is disparaging to Islam, promotes extremist ideology, or misrepresents the Qurʾān.  
 6. Subvert or disable any security, authentication, or access-control mechanism.  


### PR DESCRIPTION
## Summary

- allow QF Content covered by the Content Sync offline-cache tutorial to be stored longer than one week
- require delta checks at least every seven days and application of all available deltas
- update the Developer Terms revision date

## Why

The previous one-week storage limit predates the Content Sync offline workflow and did not account for supported long-lived offline caches.

## Developer impact

Developers using Content Sync may retain supported offline content beyond one week, provided they perform the mandatory weekly delta check and apply every available delta.

## Validation

- `git diff --check`
- verified the linked offline-cache tutorial source exists
- tests not run, per request (documentation-only change)