### PR TITLE
Restore Request Access navbar flow

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -276,10 +276,10 @@ const config = {
             label: "OAuth2 Scopes",
           },
           {
-            href: "https://dev-console.quran.foundation/projects",
-            label: "Developer Console",
+            to: "/request-access",
+            label: "Request Access",
             position: "right",
-            className: "navbar__item--developer-console",
+            className: "navbar__item--request-access",
           },
         ],
       },

--- a/scripts/postbuild-seo.js
+++ b/scripts/postbuild-seo.js
@@ -47,8 +47,6 @@ const versionedApiRoots = getVersionedApiRoots();
 const dropPathsFromSitemap = new Set([
   "/search",
   "/search/",
-  "/request-access",
-  "/request-access/",
   "/request-scopes",
   "/request-scopes/",
 ]);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -97,8 +97,8 @@ html {
   font-size: 0.9rem;
 }
 
-/* Developer Console pill button in navbar */
-.navbar__item--developer-console {
+/* Request Access pill button in navbar */
+.navbar__item--request-access {
   margin-right: 0.75rem;
 }
 
@@ -106,8 +106,8 @@ html {
   margin-left: 0.75rem;
 }
 
-.navbar__item--developer-console .navbar__link,
-a.navbar__item--developer-console {
+.navbar__item--request-access .navbar__link,
+a.navbar__item--request-access {
   background: var(--ifm-color-primary);
   color: #ffffff !important;
   border-radius: 999px;
@@ -118,8 +118,8 @@ a.navbar__item--developer-console {
   border: none;
 }
 
-.navbar__item--developer-console .navbar__link:hover,
-a.navbar__item--developer-console:hover {
+.navbar__item--request-access .navbar__link:hover,
+a.navbar__item--request-access:hover {
   background: var(--ifm-color-primary-dark);
   transform: translateY(-1px);
   text-decoration: none;
@@ -131,10 +131,10 @@ a.navbar__item--developer-console:hover {
 }
 
 @media screen and (max-width: 996px) {
-  .navbar-sidebar .navbar__item--developer-console,
-  .navbar-sidebar .navbar__item--developer-console .navbar__link,
-  .navbar-sidebar .navbar__item--developer-console .menu__link,
-  .navbar-sidebar a.navbar__item--developer-console {
+  .navbar-sidebar .navbar__item--request-access,
+  .navbar-sidebar .navbar__item--request-access .navbar__link,
+  .navbar-sidebar .navbar__item--request-access .menu__link,
+  .navbar-sidebar a.navbar__item--request-access {
     background: transparent !important;
     color: var(--qf-text-primary) !important;
     border: none !important;
@@ -146,9 +146,9 @@ a.navbar__item--developer-console:hover {
     transition: none;
   }
 
-  .navbar-sidebar .navbar__item--developer-console .navbar__link:hover,
-  .navbar-sidebar .navbar__item--developer-console .menu__link:hover,
-  .navbar-sidebar a.navbar__item--developer-console:hover {
+  .navbar-sidebar .navbar__item--request-access .navbar__link:hover,
+  .navbar-sidebar .navbar__item--request-access .menu__link:hover,
+  .navbar-sidebar a.navbar__item--request-access:hover {
     background: transparent !important;
     transform: none;
   }

--- a/static/_redirects
+++ b/static/_redirects
@@ -12,10 +12,6 @@
 /agent-prompts/qf-oauth-user-apis.md/ /agent-prompts/qf-oauth-user-apis.md 301
 /agent-prompts/qf-review-existing-integration.md/ /agent-prompts/qf-review-existing-integration.md 301
 
-# The Developer Console replaces the legacy request-access form.
-/request-access https://dev-console.quran.foundation/projects 301
-/request-access/ https://dev-console.quran.foundation/projects 301
-
 # Redirect trailing slashes to non-trailing slash URLs (optional)
 
 # Uncomment if you want to enforce no trailing slashes:

--- a/tests/developer-console-entrypoints.test.cjs
+++ b/tests/developer-console-entrypoints.test.cjs
@@ -9,18 +9,18 @@ const developerConsoleUrl = 'https://dev-console.quran.foundation/projects';
 const read = (...segments) =>
   fs.readFileSync(path.join(repoRoot, ...segments), 'utf8');
 
-test('routes interactive onboarding entry points through the Developer Console', () => {
+test('routes the navbar through the request-access screen', () => {
   const config = require(path.join(repoRoot, 'docusaurus.config.js'));
   const navbarItems = config.themeConfig.navbar.items;
-  const consoleItem = navbarItems.find(
-    (item) => item.label === 'Developer Console',
+  const requestAccessItem = navbarItems.find(
+    (item) => item.label === 'Request Access',
   );
 
-  assert.deepEqual(consoleItem, {
-    href: developerConsoleUrl,
-    label: 'Developer Console',
+  assert.deepEqual(requestAccessItem, {
+    to: '/request-access',
+    label: 'Request Access',
     position: 'right',
-    className: 'navbar__item--developer-console',
+    className: 'navbar__item--request-access',
   });
 
   for (const relativePath of [
@@ -63,7 +63,7 @@ test('routes documentation onboarding links through the Developer Console', () =
   }
 });
 
-test('routes machine discovery and retired URLs away from request access', () => {
+test('routes machine discovery through Developer Console without bypassing the request-access screen', () => {
   const card = JSON.parse(
     read('static', '.well-known', 'mcp', 'server-card.json'),
   );
@@ -83,20 +83,7 @@ test('routes machine discovery and retired URLs away from request access', () =>
   );
 
   const redirects = read('static', '_redirects');
-  assert.match(
-    redirects,
-    new RegExp(
-      `^/request-access ${developerConsoleUrl.replaceAll('.', '\\.')} 301$`,
-      'm',
-    ),
-  );
-  assert.match(
-    redirects,
-    new RegExp(
-      `^/request-access/ ${developerConsoleUrl.replaceAll('.', '\\.')} 301$`,
-      'm',
-    ),
-  );
+  assert.doesNotMatch(redirects, /^\/request-access\/?\s/m);
 
   const searchConsoleOverrides = JSON.parse(
     read('scripts', 'search-console-redirect-overrides.json'),

--- a/tests/postbuild-seo.test.cjs
+++ b/tests/postbuild-seo.test.cjs
@@ -86,9 +86,9 @@ test('drops explicit Search Console redirect sources from the sitemap', () => {
   );
 });
 
-test('drops the retired request-access redirect from the sitemap', () => {
-  assert.equal(shouldDropSitemapPath('/request-access'), true);
-  assert.equal(shouldDropSitemapPath('/request-access/'), true);
+test('keeps the request-access page in the sitemap', () => {
+  assert.equal(shouldDropSitemapPath('/request-access'), false);
+  assert.equal(shouldDropSitemapPath('/request-access/'), false);
 });
 
 test('normalizes canonical URLs with path overrides', () => {

--- a/tests/request-access-handoff.test.cjs
+++ b/tests/request-access-handoff.test.cjs
@@ -49,16 +49,16 @@ test("request access page no longer contains the legacy application form", () =>
   assert.doesNotMatch(page, /<form/);
 });
 
-test("navbar sends new developers directly to Developer Console", () => {
+test("navbar keeps the prominent request-access entry point", () => {
   const config = read("docusaurus.config.js");
 
   assert.match(
     config,
-    /href: "https:\/\/dev-console\.quran\.foundation\/projects"[\s\S]*label: "Developer Console"/
+    /to: "\/request-access"[\s\S]*label: "Request Access"/
   );
   assert.doesNotMatch(
     config,
-    /to: "\/request-access"[\s\S]*label: "Request Access"/
+    /href: "https:\/\/dev-console\.quran\.foundation\/projects"[\s\S]*label: "Developer Console"/
   );
 });
 


### PR DESCRIPTION
## What changed

- Restore the top-right **Request Access** navbar button.
- Route it to the internal `/request-access` page introduced by PR #190.
- Remove the Cloudflare redirects that bypassed that page and sent users directly to Developer Console.
- Restore the Request Access pill styling.
- Keep `/request-access` eligible for the sitemap.
- Align the affected regression assertions with the intended routing.

## Root cause

During conflict resolution between PRs #179 and #190, the direct Developer Console navbar behavior from #179 was retained. The `/request-access` redirects were also retained, which made the new access screen from #190 unreachable through the intended top-right CTA.

## Validation

Per the production-hotfix request, the test suite was intentionally not run. The diff was scope-checked and `git diff --check` passed before commit.