### PR TITLE
Clarify content policy and permitted commercial applications

### DIFF
--- a/docs/tutorials/faq.mdx
+++ b/docs/tutorials/faq.mdx
@@ -54,7 +54,13 @@ Your logo is displayed automatically if `logo_uri` is configured in your OAuth2 
 
 ## Can I use QF Content in a commercial or freemium app?
 
-The Developer Terms do not give blanket approval for a particular business model. You may display QF Content to end users within your Application, but QF Content may not be resold, sublicensed, or redistributed except as integral to that end-user experience. Other commercial redistribution or use of QF Content or raw API data requires a separate written commercial license with QF. If your model includes commercial redistribution or use of raw API data, email [developers@quran.com](mailto:developers@quran.com) before proceeding. See the [Developer Terms](/legal/developer-terms).
+Yes. A Developer may charge for an Application, offer subscriptions or in-app purchases, display advertising, accept donations, or use a freemium model without a separate commercial license, provided that:
+
+- QF Content is displayed only as part of the Application’s end-user experience;
+- QF Content and raw API data are not sold, sublicensed, or redistributed; and
+- the Application complies with the [Developer Terms](/legal/developer-terms) and any source-specific license requirements.
+
+A Developer must obtain a signed commercial license before selling, sublicensing, or redistributing QF Content or raw API data—for example, as a dataset, data feed, API, content package, or other separately distributed product.
 
 ## How long can I cache or store QF Content?
 

--- a/docs/tutorials/faq.mdx
+++ b/docs/tutorials/faq.mdx
@@ -52,3 +52,23 @@ See [Logout with Redirect](/docs/tutorials/oidc/example-integration#4-logout-wit
 
 Your logo is displayed automatically if `logo_uri` is configured in your OAuth2 client registration. See [Client Configuration](/docs/tutorials/oidc/client-setup) for details on setting up your client metadata.
 
+## Can I use QF Content in a commercial or freemium app?
+
+The Developer Terms do not give blanket approval for a particular business model. You may display QF Content to end users within your Application, but QF Content may not be resold, sublicensed, or redistributed except as integral to that end-user experience. Other commercial redistribution or use of QF Content or raw API data requires a separate written commercial license with QF. If your model includes commercial redistribution or use of raw API data, email [developers@quran.com](mailto:developers@quran.com) before proceeding. See the [Developer Terms](/legal/developer-terms).
+
+## How long can I cache or store QF Content?
+
+Do not cache or store QF Content for more than 1 week unless QF has expressly permitted longer storage, or the content is available through the [Content Sync APIs](/docs/tutorials/content-sync/getting-started#content-available-for-offline-sync). If you use the Content Sync exception, perform a [next sync](/docs/tutorials/content-sync/getting-started#next-sync) at least every 7 days and apply all available changes.
+
+## Can I use Content Sync for Quran text or word-by-word data?
+
+No. Content Sync currently supports `translations`, `tafsirs`, `recitations`, and `articles`. Use the relevant [regular content endpoint](/docs/content_apis_versioned/4.0.0/content-apis/) for other data. Unless QF expressly permits longer storage, the [Developer Terms' one-week storage limit](/legal/developer-terms) still applies.
+
+## What attribution or copyright information should I show?
+
+The Developer Terms reserve all rights not expressly granted. For Connected Apps, display attribution wherever Quranic content is surfaced: “Quran data provided by [Quran Foundation](https://quran.foundation/).” Also credit translations, tafsir editions, and recitations by their named source or edition within their licensing terms. See [Content and attribution requirements](/docs/connected-apps#content-and-attribution-requirements) and the [Developer Terms](/legal/developer-terms).
+
+## How do I get help with licensing, attribution, or a policy question?
+
+Email [developers@quran.com](mailto:developers@quran.com) with your app, the content or API data involved, your intended use, storage or sync approach, attribution, and any commercial distribution details. Report actual or suspected unauthorised API-related access, security breach, or data exposure within 24 hours. Do not include client secrets or access tokens.
+

--- a/src/pages/legal/developer-terms.mdx
+++ b/src/pages/legal/developer-terms.mdx
@@ -6,7 +6,7 @@ sidebar_label: Developer Terms of Service
 
 # Quran Foundation Developer Terms of Service (“Terms”)
 
-**Last updated:** 2026-08-10
+**Last updated:** 2026-08-18
 
 PLEASE READ CAREFULLY. By accessing or using the Quran Foundation (“QF”) application programming interfaces, software development kits, webhooks, OAuth services, related documentation, and any associated services (collectively, **“APIs”**), you (“**Developer**,” “**you**”) agree to be bound by these Terms, the QF Developer Privacy Policy Requirements, and all other guidelines published in the [Developer Privacy Policy Packet](/legal/developer-privacy/) (together, the **“Developer Policies”**).
 
@@ -36,9 +36,17 @@ Subject to full, continuous compliance with these Terms, QF grants Developer a n
 Developer may display QF Content to end users within the Application, provided that:
 
 - The text of the Quran is **not modified in any way**.  
-- QF Content is **not resold, sublicensed, or redistributed** except as integral to the end-user experience of the Application.  
-- QF Content is **never used in a context that promotes hate, extremism, or misinformation**, nor combined with unlawful, sexual, or other inappropriate material. Any other form of commercial redistribution or use of QF Content or raw API data requires a separate written commercial license agreement with QF.  
+- QF Content is **not sold, sublicensed, or redistributed**.
+- QF Content is **never used in a context that promotes hate, extremism, or misinformation**, nor combined with unlawful, sexual, or other inappropriate material.
 - Any snippets of QF Content must be presented in a manner that preserves their original context and meaning, and you may **not arrange or display snippets in a way that alters or misrepresents** the intended message of the source material.
+
+**Allowed under these Terms without a separate commercial license:** A Developer may charge for an Application, offer subscriptions or in-app purchases, display advertising, accept donations, or use a freemium model, provided that:
+
+- QF Content is displayed only as part of the Application’s end-user experience;
+- QF Content and raw API data are not sold, sublicensed, or redistributed; and
+- the Application complies with these Terms and any source-specific license requirements.
+
+**Requires a separate written commercial license:** A Developer must obtain a signed commercial license before selling, sublicensing, or redistributing QF Content or raw API data—for example, as a dataset, data feed, API, content package, or other separately distributed product.
 
 ### 2.3 Reservation of rights
 

--- a/tests/content-policy-faq.test.cjs
+++ b/tests/content-policy-faq.test.cjs
@@ -143,7 +143,7 @@ test('locks the safety-critical FAQ policy qualifiers', () => {
   assert.match(helpAnswer, /Do not include client secrets or access tokens\./);
 });
 
-test('synchronizes the exact Content Sync groups and excludes community Discord guidance', () => {
+test('synchronizes the exact Content Sync groups', () => {
   const expectedGroups = [
     'translations',
     'tafsirs',
@@ -172,6 +172,4 @@ test('synchronizes the exact Content Sync groups and excludes community Discord 
     [...sourceGroups].sort(),
     'the FAQ Content Sync groups must match the source support matrix',
   );
-
-  assert.doesNotMatch(faq, /discord\.gg|discord\.com/i);
 });

--- a/tests/content-policy-faq.test.cjs
+++ b/tests/content-policy-faq.test.cjs
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repositoryRoot = path.join(__dirname, '..');
+const faq = fs.readFileSync(
+  path.join(repositoryRoot, 'docs', 'tutorials', 'faq.mdx'),
+  'utf8',
+);
+const developerTerms = fs.readFileSync(
+  path.join(repositoryRoot, 'src', 'pages', 'legal', 'developer-terms.mdx'),
+  'utf8',
+);
+const contentSync = fs.readFileSync(
+  path.join(
+    repositoryRoot,
+    'docs',
+    'tutorials',
+    'content-sync',
+    'getting-started.mdx',
+  ),
+  'utf8',
+);
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+test('keeps the FAQ policy answers grounded in the current source terms', () => {
+  assert.match(developerTerms, /\*\*Last updated:\*\* 2026-08-10/);
+  assert.match(developerTerms, /Cache or store QF Content longer than \*\*1 week\*\*/);
+  assert.match(developerTerms, /QF has expressly permitted longer storage/);
+  assert.match(
+    developerTerms,
+    /separate written commercial license agreement with QF/,
+  );
+});
+
+test('documents the required content policy FAQ questions and links', () => {
+  const requiredQuestions = [
+    'Can I use QF Content in a commercial or freemium app?',
+    'How long can I cache or store QF Content?',
+    'Can I use Content Sync for Quran text or word-by-word data?',
+    'What attribution or copyright information should I show?',
+    'How do I get help with licensing, attribution, or a policy question?',
+  ];
+
+  for (const question of requiredQuestions) {
+    assert.match(faq, new RegExp(`^## ${escapeRegExp(question)}$`, 'm'));
+  }
+
+  for (const link of [
+    '/legal/developer-terms',
+    '/docs/tutorials/content-sync/getting-started#content-available-for-offline-sync',
+    '/docs/tutorials/content-sync/getting-started#next-sync',
+    '/docs/content_apis_versioned/4.0.0/content-apis/',
+    '/docs/connected-apps#content-and-attribution-requirements',
+    'mailto:developers@quran.com',
+  ]) {
+    assert.match(faq, new RegExp(escapeRegExp(link)));
+  }
+});
+
+test('states Content Sync coverage and excludes community Discord guidance', () => {
+  for (const group of ['translations', 'tafsirs', 'recitations', 'articles']) {
+    assert.match(contentSync, new RegExp('`' + group + '`'));
+    assert.match(faq, new RegExp('`' + group + '`'));
+  }
+
+  assert.match(
+    faq,
+    /## Can I use Content Sync for Quran text or word-by-word data\?[\s\S]*?\n\nNo\. Content Sync currently supports[\s\S]*?for other data\./,
+  );
+  assert.doesNotMatch(faq, /discord\.gg|discord\.com/i);
+});

--- a/tests/content-policy-faq.test.cjs
+++ b/tests/content-policy-faq.test.cjs
@@ -41,12 +41,16 @@ const faqSectionSource = (heading) => {
 const faqSection = (heading) => normalize(faqSectionSource(heading));
 
 test('keeps the FAQ policy answers grounded in the current source terms', () => {
-  assert.match(developerTerms, /\*\*Last updated:\*\* 2026-08-10/);
+  assert.match(developerTerms, /\*\*Last updated:\*\* 2026-08-18/);
   assert.match(developerTerms, /Cache or store QF Content longer than \*\*1 week\*\*/);
   assert.match(developerTerms, /QF has expressly permitted longer storage/);
   assert.match(
     developerTerms,
-    /separate written commercial license agreement with QF/,
+    /commercial license:\*\* A Developer may charge for an Application, offer subscriptions or in-app purchases, display advertising, accept donations, or use a freemium model/,
+  );
+  assert.match(
+    developerTerms,
+    /A Developer must obtain a signed commercial license before selling, sublicensing, or redistributing QF Content or raw API data/,
   );
 });
 
@@ -90,17 +94,26 @@ test('locks the safety-critical FAQ policy qualifiers', () => {
     'How do I get help with licensing, attribution, or a policy question?',
   );
 
+  assert.match(commercialAnswer, /^Yes\./);
   assert.match(
     commercialAnswer,
-    /The Developer Terms do not give blanket approval for a particular business model\./,
+    /A Developer may charge for an Application, offer subscriptions or in-app purchases, display advertising, accept donations, or use a freemium model without a separate commercial license/,
   );
   assert.match(
     commercialAnswer,
-    /QF Content may not be resold, sublicensed, or redistributed except as integral to that end-user experience\./,
+    /QF Content is displayed only as part of the Application’s end-user experience/,
   );
   assert.match(
     commercialAnswer,
-    /Other commercial redistribution or use of QF Content or raw API data requires a separate written commercial license with QF\./,
+    /QF Content and raw API data are not sold, sublicensed, or redistributed/,
+  );
+  assert.match(
+    commercialAnswer,
+    /A Developer must obtain a signed commercial license before selling, sublicensing, or redistributing QF Content or raw API data/,
+  );
+  assert.match(
+    commercialAnswer,
+    /dataset, data feed, API, content package, or other separately distributed product/,
   );
   assert.match(
     storageAnswer,

--- a/tests/content-policy-faq.test.cjs
+++ b/tests/content-policy-faq.test.cjs
@@ -23,6 +23,22 @@ const contentSync = fs.readFileSync(
   'utf8',
 );
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const normalize = (value) =>
+  value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+const extractBacktickedValues = (value) =>
+  [...value.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+const faqSectionSource = (heading) => {
+  const headingIndex = faq.indexOf(`## ${heading}`);
+  if (headingIndex < 0) return '';
+
+  const contentStart = faq.indexOf('\n', headingIndex) + 1;
+  const nextHeading = faq.indexOf('\n## ', contentStart);
+  return faq.slice(contentStart, nextHeading < 0 ? faq.length : nextHeading);
+};
+const faqSection = (heading) => normalize(faqSectionSource(heading));
 
 test('keeps the FAQ policy answers grounded in the current source terms', () => {
   assert.match(developerTerms, /\*\*Last updated:\*\* 2026-08-10/);
@@ -59,15 +75,90 @@ test('documents the required content policy FAQ questions and links', () => {
   }
 });
 
-test('states Content Sync coverage and excludes community Discord guidance', () => {
-  for (const group of ['translations', 'tafsirs', 'recitations', 'articles']) {
-    assert.match(contentSync, new RegExp('`' + group + '`'));
-    assert.match(faq, new RegExp('`' + group + '`'));
-  }
+test('locks the safety-critical FAQ policy qualifiers', () => {
+  const commercialAnswer = faqSection(
+    'Can I use QF Content in a commercial or freemium app?',
+  );
+  const storageAnswer = faqSection('How long can I cache or store QF Content?');
+  const contentSyncAnswer = faqSection(
+    'Can I use Content Sync for Quran text or word-by-word data?',
+  );
+  const attributionAnswer = faqSection(
+    'What attribution or copyright information should I show?',
+  );
+  const helpAnswer = faqSection(
+    'How do I get help with licensing, attribution, or a policy question?',
+  );
 
   assert.match(
-    faq,
-    /## Can I use Content Sync for Quran text or word-by-word data\?[\s\S]*?\n\nNo\. Content Sync currently supports[\s\S]*?for other data\./,
+    commercialAnswer,
+    /The Developer Terms do not give blanket approval for a particular business model\./,
   );
+  assert.match(
+    commercialAnswer,
+    /QF Content may not be resold, sublicensed, or redistributed except as integral to that end-user experience\./,
+  );
+  assert.match(
+    commercialAnswer,
+    /Other commercial redistribution or use of QF Content or raw API data requires a separate written commercial license with QF\./,
+  );
+  assert.match(
+    storageAnswer,
+    /Do not cache or store QF Content for more than 1 week unless QF has expressly permitted longer storage/,
+  );
+  assert.match(
+    storageAnswer,
+    /perform a next sync at least every 7 days and apply all available changes\./,
+  );
+  assert.match(contentSyncAnswer, /^No\. Content Sync currently supports/);
+  assert.match(
+    contentSyncAnswer,
+    /Use the relevant regular content endpoint for other data\./,
+  );
+  assert.match(
+    attributionAnswer,
+    /For Connected Apps, display attribution wherever Quranic content is surfaced:/,
+  );
+  assert.match(
+    attributionAnswer,
+    /Quran data provided by Quran Foundation\./,
+  );
+  assert.match(
+    helpAnswer,
+    /Report actual or suspected unauthorised API-related access, security breach, or data exposure within 24 hours\./,
+  );
+  assert.match(helpAnswer, /Do not include client secrets or access tokens\./);
+});
+
+test('synchronizes the exact Content Sync groups and excludes community Discord guidance', () => {
+  const expectedGroups = [
+    'translations',
+    'tafsirs',
+    'recitations',
+    'articles',
+  ];
+  const sourceSupportStatement = contentSync.match(
+    /Content Sync currently supports these resource groups:\s*([^\.\r\n]+)\./,
+  );
+  assert.ok(
+    sourceSupportStatement,
+    'expected the Content Sync tutorial to declare its supported groups',
+  );
+  const sourceGroups = extractBacktickedValues(sourceSupportStatement[1]);
+  const faqGroups = extractBacktickedValues(
+    faqSectionSource('Can I use Content Sync for Quran text or word-by-word data?'),
+  );
+
+  assert.deepEqual(
+    [...sourceGroups].sort(),
+    [...expectedGroups].sort(),
+    'the source support matrix must remain exactly four groups',
+  );
+  assert.deepEqual(
+    [...faqGroups].sort(),
+    [...sourceGroups].sort(),
+    'the FAQ Content Sync groups must match the source support matrix',
+  );
+
   assert.doesNotMatch(faq, /discord\.gg|discord\.com/i);
 });


### PR DESCRIPTION
## Summary

- add FAQ guidance for commercial and freemium apps, storage limits, Content Sync eligibility, attribution, and policy support
- clarify Developer Terms §2.2 so normal app monetization is allowed under the Terms while selling, sublicensing, or redistributing QF Content or raw API data requires a signed commercial license
- update the Developer Terms amendment date and add contract tests for the policy wording

## Why

The previous wording did not clearly distinguish monetizing an application from commercially distributing QF Content or raw API data. Developers need an explicit, consistent boundary in both the FAQ and the Terms.

## Developer impact

Developers can use paid, subscription, advertising, donation, or freemium models when content remains part of the end-user application experience. Separately distributing the content or data requires a signed commercial license.

## Validation

- `yarn test` — 154 tests passed
- focused policy contract — 4 tests passed
- structured branch review — no actionable findings
