### PR TITLE
Fix analytics OpenAPI deployment failure

### DIFF
--- a/openAPI/analytics/v1.json
+++ b/openAPI/analytics/v1.json
@@ -242,9 +242,6 @@
             }
           }
         },
-        "x-qf-live-request-current-timestamp-fields": [
-          "occurred_at"
-        ],
         "x-code-samples": [
           {
             "label": "cURL",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tsconfig/docusaurus": "^1.0.5",
     "domutils": "^3.0.1",
     "htmlparser2": "^8.0.1",
+    "js-yaml": "^4.1.0",
     "mermaid": "9.4.3",
     "typescript": "^4.7.4",
     "wrangler": "^4.42.0"

--- a/tests/openapi-syntax.test.cjs
+++ b/tests/openapi-syntax.test.cjs
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const openApiDir = path.join(__dirname, '..', 'openAPI');
+
+const collectJsonFiles = (dir) => {
+  const files = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectJsonFiles(entryPath));
+    } else if (entry.name.endsWith('.json')) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+test('OpenAPI documents have valid syntax and unique mapping keys', () => {
+  for (const filePath of collectJsonFiles(openApiDir)) {
+    const relativePath = path.relative(path.join(__dirname, '..'), filePath);
+    const contents = fs.readFileSync(filePath, 'utf8');
+
+    assert.doesNotThrow(
+      () => yaml.load(contents),
+      `${relativePath} must parse without duplicate mapping keys`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- remove the duplicate `x-qf-live-request-current-timestamp-fields` key from the analytics OpenAPI document
- keep the docs copy byte-for-byte aligned with the ingestion service export
- validate all checked-in OpenAPI documents with a parser that rejects duplicate mapping keys

## Root cause
An automated analytics OpenAPI publication landed before PR #195. The later merge retained both copies of the timestamp extension, producing valid JSON for permissive parsers but invalid input for Redocly. Cloudflare Pages failed while generating analytics docs at line 255.

## Verification
- `node --test tests/openapi-syntax.test.cjs`
- `yarn test` (164 passing)
- `yarn re-gen && npx docusaurus build && yarn postbuild:seo`
- corrected `openAPI/analytics/v1.json` matches `qf-analytics-ingest` `export_openapi` output